### PR TITLE
adds asumMap to Foldable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   Add `under2` and `underF2` functions to `Relude.Extra.Newtype`.
 * [#60](https://github.com/kowainik/relude/issues/60):
   Add `hoistMaybe` and `hoistEither` functions.
+* [#81](https://github.com/kowainik/relude/issues/81):
+  Add `asumMap` to `Foldable` functions.
 
 0.2.0
 =====

--- a/src/Relude/Foldable/Fold.hs
+++ b/src/Relude/Foldable/Fold.hs
@@ -20,6 +20,7 @@ Fixes and additions to 'Foldable'.
 module Relude.Foldable.Fold
        ( flipfoldl'
        , foldMapA
+       , asumMap
        , foldMapM
        , sum
        , product
@@ -39,7 +40,7 @@ module Relude.Foldable.Fold
 
 import GHC.TypeLits (ErrorMessage (..), TypeError)
 
-import Relude.Applicative (Applicative (..), pure)
+import Relude.Applicative (Alternative, Applicative (..), pure)
 import Relude.Base (Constraint, Eq, IO, Num (..), Type, ($!))
 import Relude.Bool (Bool (..))
 import Relude.Container.Reexport (HashSet, Set)
@@ -47,7 +48,7 @@ import Relude.Foldable.Reexport (Foldable (..))
 import Relude.Function (flip, (.))
 import Relude.Functor ((<$>))
 import Relude.Monad.Reexport (Monad (..))
-import Relude.Monoid (Monoid (..))
+import Relude.Monoid (Alt(..), Monoid (..))
 
 import qualified Data.Foldable as F
 
@@ -75,6 +76,13 @@ foldMapA f = foldr step (pure mempty)
   where
     step a mb = mappend <$> f a <*> mb
 {-# INLINE foldMapA #-}
+
+{- | Alternative version of @asum@
+>>> asumMap (\x -> if x > 2 then Just x else Nothing) [1..3]
+Just 3
+-}
+asumMap :: (Foldable f, Alternative m) => (a -> m b) -> f a -> m b
+asumMap f = getAlt . foldMap (\a -> Alt (f a))
 
 {- | Polymorphic version of @concatMapM@ function.
 


### PR DESCRIPTION
Resolves #81

Not much to say here. I added imports for `Alt` from `Applicative` to be able to treat `Alternative` as a monoid, which made the function implementation quite simple.

## Checklist:

I'm not exactly sure if I should have added anything to the `hlint.dhall` file for this change.

### HLint

- [x] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall)
        accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see 
        [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) 
      with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see 
      [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) 
      for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
