### PR TITLE
Remove openFile and hClose

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1709,16 +1709,6 @@
     name: Use 'writeTVar' from Relude
     rhs: writeTVar
 - warn:
-    lhs: System.IO.openFile
-    note: ! '''openFile'' is already exported from Relude'
-    name: Use 'openFile' from Relude
-    rhs: openFile
-- warn:
-    lhs: System.IO.hClose
-    note: ! '''hClose'' is already exported from Relude'
-    name: Use 'hClose' from Relude
-    rhs: hClose
-- warn:
     lhs: Data.IORef.IORef
     note: ! '''IORef'' is already exported from Relude'
     name: Use 'IORef' from Relude
@@ -2553,16 +2543,6 @@
     note: If you import 'die' from Relude, it's already lifted
     name: ! '''liftIO'' is not needed'
     rhs: die
-- warn:
-    lhs: (liftIO (openFile x y))
-    note: If you import 'openFile' from Relude, it's already lifted
-    name: ! '''liftIO'' is not needed'
-    rhs: openFile
-- warn:
-    lhs: (liftIO (hClose x))
-    note: If you import 'hClose' from Relude, it's already lifted
-    name: ! '''liftIO'' is not needed'
-    rhs: hClose
 - warn:
     lhs: (liftIO (readFile x))
     note: If you import 'readFile' from Relude, it's already lifted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-0.3.1
+0.4.0
 =====
 * [#81](https://github.com/kowainik/relude/issues/81):
   Add `asumMap` to `Foldable` functions.
@@ -9,6 +9,7 @@
 * [#92](https://github.com/kowainik/relude/issues/92)
   Add `Relude.Extra.Tuple` module, containing
   `dupe`, `mapToFst`, `mapToSnd`, and `mapBoth` functions.
+* Remove `openFile` and `hClose`.
 
 0.3.0
 =====

--- a/hlint/hlint.dhall
+++ b/hlint/hlint.dhall
@@ -554,11 +554,6 @@ in [ rule.Arguments { arguments =
    , warnReexport "readTVar" "Control.Concurrent.STM.TVar"
    , warnReexport "writeTVar" "Control.Concurrent.STM.TVar"
 
-   -- Lifted File
-   , warnReexport "openFile" "System.IO"
-   , warnReexport "hClose"   "System.IO"
-
-
    -- Lifted IORef
    , warnReexport "IORef" "Data.IORef"
    , warnReexport "atomicModifyIORef" "Data.IORef"
@@ -744,8 +739,6 @@ in [ rule.Arguments { arguments =
    , warnLifted "exitSuccess" ""
    , warnLifted "die" "x"
    -- File
-   , warnLifted "openFile" "x y"
-   , warnLifted "hClose" "x"
    , warnLifted "readFile" "x"
    , warnLifted "writeFile" "x y"
    , warnLifted "appendFile" "x y"

--- a/relude.cabal
+++ b/relude.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                relude
-version:             0.3.1
+version:             0.4.0
 synopsis:            Custom prelude from Kowainik
 description:
     == Goals

--- a/src/Relude/Extra/Tuple.hs
+++ b/src/Relude/Extra/Tuple.hs
@@ -13,8 +13,8 @@ module Relude.Extra.Tuple
        , mapBoth
        ) where
 
-import Relude -- necessary import for doctests
-
+-- $setup
+-- >>> import Relude
 
 {- | Creates a tuple by pairing something with itself.
 

--- a/src/Relude/Lifted/File.hs
+++ b/src/Relude/Lifted/File.hs
@@ -12,11 +12,9 @@ module Relude.Lifted.File
        ( readFile
        , writeFile
        , appendFile
-       , openFile
-       , hClose
        ) where
 
-import Relude.Base (FilePath, Handle, IO, IOMode, String)
+import Relude.Base (FilePath, IO, String)
 import Relude.Function ((.))
 import Relude.Monad.Reexport (MonadIO (..))
 
@@ -40,15 +38,3 @@ appendFile :: MonadIO m => FilePath -> String -> m ()
 appendFile p = liftIO . IO.appendFile p
 {-# SPECIALIZE appendFile :: FilePath -> String -> IO () #-}
 {-# INLINE appendFile #-}
-
--- | Lifted version of 'IO.openFile'.
-openFile :: MonadIO m => FilePath -> IOMode -> m Handle
-openFile p = liftIO . IO.openFile p
-{-# SPECIALIZE openFile :: FilePath -> IOMode -> IO Handle #-}
-{-# INLINE openFile #-}
-
--- | Lifted version of 'IO.hClose'.
-hClose :: MonadIO m => Handle -> m ()
-hClose = liftIO . hClose
-{-# SPECIALIZE hClose :: Handle -> IO () #-}
-{-# INLINE hClose #-}


### PR DESCRIPTION
It's not safe to use those functions without `bracket` anyways. And if you want to use `openFile` and `hClose` with `bracket`, we already reexport `withFile`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [x] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [x] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [x] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
