### PR TITLE
[#97] Added monadic version of (&&) and (||) operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   Add `Relude.Extra.Tuple` module, containing
   `dupe`, `mapToFst`, `mapToSnd`, and `mapBoth` functions.
 * Remove `openFile` and `hClose`.
+* [#97](https://github.com/kowainik/relude/issues/97):
+  Add `(&&^)` and `(||^)` operators.
 
 0.3.0
 =====

--- a/src/Relude/Bool/Guard.hs
+++ b/src/Relude/Bool/Guard.hs
@@ -13,11 +13,13 @@ module Relude.Bool.Guard
        , ifM
        , unlessM
        , whenM
+       , (&&^)
+       , (||^)
        ) where
 
-import Relude.Bool.Reexport (Bool, guard, unless, when)
+import Relude.Bool.Reexport (Bool (..), guard, unless, when)
 import Relude.Function (flip)
-import Relude.Monad (Monad, MonadPlus, (>>=))
+import Relude.Monad (Monad, return, MonadPlus, (>>=))
 
 -- $setup
 -- >>> import Relude.Applicative (pure)
@@ -73,3 +75,19 @@ ifM p x y = p >>= \b -> if b then x else y
 guardM :: MonadPlus m => m Bool -> m ()
 guardM f = f >>= guard
 {-# INLINE guardM #-}
+
+-- | Monadic version of 'Data.Bool.(&&)' operator.
+--
+-- >>> Just False &&^ undefined
+-- Just False
+(&&^) :: Monad m => m Bool -> m Bool -> m Bool
+(&&^) e1 e2 = ifM e1 e2 (return False)
+{-# INLINE (&&^) #-}
+
+-- | Monadic version of 'Data.Bool.(||)' operator.
+--
+-- >>> Just True ||^ undefined
+-- Just True
+(||^) :: Monad m => m Bool -> m Bool -> m Bool
+(||^) e1 e2 = ifM e1 (return True) e2
+{-# INLINE (||^) #-}


### PR DESCRIPTION
Resolves #97 

Added monadic version of boolean operators.

## Checklist:

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [X] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [X] All new and existing tests pass.
- [X] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [X] My change requires the documentation updates.
  - [X] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
