### PR TITLE
Fix doctests in `Relude.Bool.Guard`

### DIFF
--- a/src/Relude/Bool/Guard.hs
+++ b/src/Relude/Bool/Guard.hs
@@ -24,6 +24,7 @@ import Relude.Monad (Monad, return, MonadPlus, (>>=))
 -- $setup
 -- >>> import Relude.Applicative (pure)
 -- >>> import Relude.Bool.Reexport (Bool (..))
+-- >>> import Relude.Debug (undefined)
 -- >>> import Relude.Function (($))
 -- >>> import Relude.Monad (Maybe (..))
 -- >>> import Relude.Print (putTextLn)
@@ -78,6 +79,7 @@ guardM f = f >>= guard
 
 -- | Monadic version of 'Data.Bool.(&&)' operator.
 --
+-- >>> :set -Wno-deprecations
 -- >>> Just False &&^ undefined
 -- Just False
 (&&^) :: Monad m => m Bool -> m Bool -> m Bool
@@ -86,6 +88,7 @@ guardM f = f >>= guard
 
 -- | Monadic version of 'Data.Bool.(||)' operator.
 --
+-- >>> :set -Wno-deprecations
 -- >>> Just True ||^ undefined
 -- Just True
 (||^) :: Monad m => m Bool -> m Bool -> m Bool

--- a/src/Relude/Bool/Guard.hs
+++ b/src/Relude/Bool/Guard.hs
@@ -24,7 +24,7 @@ import Relude.Monad (Monad, return, MonadPlus, (>>=))
 -- $setup
 -- >>> import Relude.Applicative (pure)
 -- >>> import Relude.Bool.Reexport (Bool (..))
--- >>> import Relude.Debug (undefined)
+-- >>> import Relude.Debug (error)
 -- >>> import Relude.Function (($))
 -- >>> import Relude.Monad (Maybe (..))
 -- >>> import Relude.Print (putTextLn)
@@ -79,8 +79,7 @@ guardM f = f >>= guard
 
 -- | Monadic version of 'Data.Bool.(&&)' operator.
 --
--- >>> :set -Wno-deprecations
--- >>> Just False &&^ undefined
+-- >>> Just False &&^ error "Shouldn't be evaluated"
 -- Just False
 (&&^) :: Monad m => m Bool -> m Bool -> m Bool
 (&&^) e1 e2 = ifM e1 e2 (return False)
@@ -88,8 +87,7 @@ guardM f = f >>= guard
 
 -- | Monadic version of 'Data.Bool.(||)' operator.
 --
--- >>> :set -Wno-deprecations
--- >>> Just True ||^ undefined
+-- >>> Just True ||^ error "Shouldn't be evaluated"
 -- Just True
 (||^) :: Monad m => m Bool -> m Bool -> m Bool
 (||^) e1 e2 = ifM e1 (return True) e2


### PR DESCRIPTION
This PR fixes the doctests in `Relude.Bool.Guard` module.

### General

- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
