### PR TITLE
Move to dhall 3.0.0

### DIFF
--- a/hlint/warn.dhall
+++ b/hlint/warn.dhall
@@ -4,10 +4,10 @@ in let warnSimple
     : Text -> Text -> Rule
     = \(lhsTxt : Text) -> \(rhsTxt : Text) ->
         rule.Warn {warn =
-            { name = [] : Optional Text
+            { name = None Text
             , lhs = "${lhsTxt}"
             , rhs = "${rhsTxt}"
-            , note = [] : Optional Text
+            , note = None Text
             }
         }
 
@@ -15,10 +15,10 @@ in let warnNote
     : Text -> Text -> Text -> Rule
     = \(lhsTxt : Text) -> \(rhsTxt : Text) -> \(n : Text) ->
         rule.Warn {warn =
-            { name = [] : Optional Text
+            { name = None Text
             , lhs = "${lhsTxt}"
             , rhs = "${rhsTxt}"
-            , note = ["${n}"] : Optional Text
+            , note = Some "${n}"
             }
         }
 
@@ -26,20 +26,20 @@ in let warnReexport
     : Text -> Text -> Rule
     = \(f : Text) -> \(mod : Text) ->
         rule.Warn {warn =
-            { name = ["Use '${f}' from Relude"] : Optional Text
+            { name = Some "Use '${f}' from Relude"
             , lhs = "${mod}.${f}"
             , rhs = "${f}"
-            , note = ["'${f}' is already exported from Relude"] : Optional Text
+            , note = Some "'${f}' is already exported from Relude"
             }
         }
 
 in let warnReexportOp : Text -> Text -> Rule
     = \(f : Text) -> \(mod : Text) ->
         rule.Warn {warn =
-            { name = ["Use '${f}' from Relude"] : Optional Text
+            { name = Some "Use '${f}' from Relude"
             , lhs = "(${mod}.${f})"
             , rhs = "(${f})"
-            , note = ["Operator '(${f})' is already exported from Relude"] : Optional Text
+            , note = Some "Operator '(${f})' is already exported from Relude"
             }
         }
 
@@ -47,10 +47,10 @@ in let warnLifted
     : Text -> Text -> Rule
     =  \(f : Text) -> \(args : Text) ->
         rule.Warn { warn =
-            { name = ["'liftIO' is not needed"] : Optional Text
+            { name = Some "'liftIO' is not needed"
             , lhs = "(liftIO (${f} ${args}))"
             , rhs = "${f}"
-            , note = ["If you import '${f}' from Relude, it's already lifted"] : Optional Text
+            , note = Some "If you import '${f}' from Relude, it's already lifted"
             }
         }
 
@@ -60,7 +60,7 @@ in let hintNote
         rule.Hint { hint =
             { lhs = "(${lhsTxt})"
             , rhs = "${rhsTxt}"
-            , note = ["${n}"] : Optional Text
+            , note = Some "${n}"
             }
         }
 


### PR DESCRIPTION
Use the Some and None keywords in warn.dhall
to take advantage of new features in dhall 3.0.0

Resolves #109 

The generated hlint.yaml file is identical to the old one.
## Checklist:

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [X] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [X] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [ ] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
