### PR TITLE
[#112] Add an explicit step for the relude dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ the following steps:
 
 1. Replace `base` dependency with corresponding version of `base-noprelude` in
    your `.cabal` file.
-2. Add the following `Prelude` module to your project (both to filesystem and to `exposed-modules`):
+2. Add a `relude` dependency to your `.cabal` file.
+3. Add the following `Prelude` module to your project (both to filesystem and to `exposed-modules`):
    ```haskell
    module Prelude
           ( module Relude
@@ -89,7 +90,7 @@ the following steps:
    ```
    > **NOTE:** if you use [`summoner`](https://github.com/kowainik/summoner) to generate Haskell project,
    > this tool can automatically create such structure for you when you specify custom prelude.
-3. Optionally modify your `Prelude` to include more or less functions. Probably
+4. Optionally modify your `Prelude` to include more or less functions. Probably
    you want to hide something from `Relude` module. Or maybe you want to add
    something from `Relude.Extra.*` modules!
 


### PR DESCRIPTION
Before we left adding the relude dependency as an implicit
step in the usage instructions; It's probably better if
we make this explicit.

Resolves #112

This is a relatively simple documentation fix. I haven't updated the changelog because
I feel like this is more of a slight documentation fix than something warranting a note in the changelog;
adding it would be simple of course ;)

## Checklist:

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [ ] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [X] My change requires the documentation updates.
  - [X] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
