### PR TITLE
Isolated numerical functions in Relude.Numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Unreleased
 ====
 
+0.5.0
+=====
+
+* [#125](https://github.com/kowainik/relude/issues/125):
+  Moved many numerical functions and types in `Relude.Numeric`.    
+  It reexports `toIntegralSized` and exports `integerToBounded` and `integerToNatural`
+
 0.4.0 — Nov 6, 2018
 =====
 

--- a/relude.cabal
+++ b/relude.cabal
@@ -105,13 +105,14 @@ library
                                Relude.Monad.Trans
                            Relude.Monoid
                            Relude.Nub
+                           Relude.Numeric
                            Relude.Print
                            Relude.String
                                Relude.String.Conversion
                                Relude.String.Reexport
 
                            -- not exported by default
-                           Relude.Extra.Bifunctor                          
+                           Relude.Extra.Bifunctor
                            Relude.Extra.CallStack
                            Relude.Extra.Enum
                            Relude.Extra.Foldable1

--- a/src/Relude.hs
+++ b/src/Relude.hs
@@ -114,6 +114,7 @@ module Relude
        , module Relude.Monad
        , module Relude.Monoid
        , module Relude.Nub
+       , module Relude.Numeric
        , module Relude.Print
        , module Relude.String
        ) where
@@ -134,5 +135,6 @@ import Relude.List
 import Relude.Monad
 import Relude.Monoid
 import Relude.Nub
+import Relude.Numeric
 import Relude.Print
 import Relude.String

--- a/src/Relude/Base.hs
+++ b/src/Relude/Base.hs
@@ -16,9 +16,7 @@ module Relude.Base
        ( -- * Base types
          module Data.Bits
        , module Data.Char
-       , module Data.Int
        , module Data.Word
-       , Natural
 
          -- * Base type classes
        , module Data.Eq
@@ -36,10 +34,7 @@ module Relude.Base
 
        , module GHC.Base
        , module GHC.Enum
-       , module GHC.Float
        , module GHC.Generics
-       , module GHC.Num
-       , module GHC.Real
        , module GHC.Show
 
 #if MIN_VERSION_base(4,10,0)
@@ -56,9 +51,7 @@ module Relude.Base
 -- Base types
 import Data.Bits (xor)
 import Data.Char (Char, chr)
-import Data.Int (Int, Int16, Int32, Int64, Int8)
 import Data.Word (Word, Word16, Word32, Word64, Word8, byteSwap16, byteSwap32, byteSwap64)
-import Numeric.Natural (Natural)
 
 -- IO
 import System.IO (FilePath, Handle, IO, IOMode (..), stderr, stdin, stdout, withFile)
@@ -76,11 +69,7 @@ import Data.Void (Void, absurd, vacuous)
 
 import GHC.Base (String, asTypeOf, maxInt, minInt, ord, seq, ($!))
 import GHC.Enum (Bounded (..), Enum (..), boundedEnumFrom, boundedEnumFromThen)
-import GHC.Float (Double (..), Float (..), Floating (acos, acosh, asin, asinh, atan, atanh, cos, cosh, exp, logBase, pi, sin, sinh, sqrt, tan, tanh, (**)))
 import GHC.Generics (Generic)
-import GHC.Num (Integer, Num (..), subtract)
-import GHC.Real (Fractional (..), Integral (..), Ratio, Rational, Real (..), RealFrac (..),
-                 denominator, even, fromIntegral, gcd, lcm, numerator, odd, realToFrac, (^), (^^))
 import GHC.Show (Show)
 
 #if MIN_VERSION_base(4,10,0)

--- a/src/Relude/Container/One.hs
+++ b/src/Relude/Container/One.hs
@@ -16,8 +16,9 @@ module Relude.Container.One
        ( One (..)
        ) where
 
-import Relude.Base (Char, Int, Word8)
+import Relude.Base (Char, Word8)
 import Relude.Container.Reexport (HashMap, HashSet, Hashable, IntMap, IntSet, Map, Set, uncurry)
+import Relude.Numeric (Int)
 
 import qualified Data.List.NonEmpty as NE
 
@@ -37,8 +38,9 @@ import qualified Data.Map as M
 import qualified Data.Set as Set
 
 -- $setup
--- >>> import Relude.Base (Int, String)
+-- >>> import Relude.Base (String)
 -- >>> import Relude.Bool (Bool (..))
+-- >>> import Relude.Numeric (Int)
 -- >>> import Relude.String (Text)
 -- >>> import qualified Data.HashMap.Strict as HashMap
 

--- a/src/Relude/Extra/Map.hs
+++ b/src/Relude/Extra/Map.hs
@@ -25,12 +25,13 @@ module Relude.Extra.Map
 import GHC.Exts (IsList (Item, toList))
 
 import Relude.Applicative (pure, (*>))
-import Relude.Base (Eq, Int, Ord, Type)
+import Relude.Base (Eq, Ord, Type)
 import Relude.Bool (Bool, guard, not)
 import Relude.Container.Reexport (HashMap, HashSet, Hashable, IntMap, IntSet, Map, Set, fst, snd)
 import Relude.Function ((.))
 import Relude.List (map)
 import Relude.Monad.Reexport (Maybe (..), fromMaybe)
+import Relude.Numeric (Int)
 
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS

--- a/src/Relude/Foldable/Fold.hs
+++ b/src/Relude/Foldable/Fold.hs
@@ -41,14 +41,15 @@ module Relude.Foldable.Fold
 import GHC.TypeLits (ErrorMessage (..), TypeError)
 
 import Relude.Applicative (Alternative, Applicative (..), pure)
-import Relude.Base (Constraint, Eq, IO, Num (..), Type, ($!))
+import Relude.Base (Constraint, Eq, IO, Type, ($!))
 import Relude.Bool (Bool (..))
 import Relude.Container.Reexport (HashSet, Set)
 import Relude.Foldable.Reexport (Foldable (..))
 import Relude.Function (flip, (.))
 import Relude.Functor ((<$>))
 import Relude.Monad.Reexport (Monad (..))
-import Relude.Monoid (Alt(..), Monoid (..))
+import Relude.Monoid (Alt (..), Monoid (..))
+import Relude.Numeric (Num (..))
 
 import qualified Data.Foldable as F
 

--- a/src/Relude/Functor/Fmap.hs
+++ b/src/Relude/Functor/Fmap.hs
@@ -35,9 +35,9 @@ as <&> f = f <$> as
 #endif
 
 -- $setup
--- >>> import Relude.Base (negate, (*), (+))
 -- >>> import Relude.Monad (Maybe (..))
 -- >>> import Relude.List ((++))
+-- >>> import Relude.Numeric (negate, (*), (+))
 
 {- | Alias for @fmap . fmap@. Convenient to work with two nested 'Functor's.
 

--- a/src/Relude/Monoid.hs
+++ b/src/Relude/Monoid.hs
@@ -22,8 +22,8 @@ import Data.Semigroup (Option (..), Semigroup (sconcat, stimes, (<>)), WrappedMo
 import Relude.Monad.Reexport (Maybe, fromMaybe)
 
 -- $setup
--- >>> import Relude.Base (Int)
 -- >>> import Relude.Monad (Maybe (..))
+-- >>> import Relude.Numeric (Int)
 
 -- | Extracts 'Monoid' value from 'Maybe' returning 'mempty' if 'Nothing'.
 --

--- a/src/Relude/Numeric.hs
+++ b/src/Relude/Numeric.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE RankNTypes #-}
+
+{- |
+Copyright: (c) 2018 Kowainik
+License:    MIT
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+-}
+
+module Relude.Numeric
+       ( module Data.Bits
+       , module Data.Int
+       , module Numeric
+       , module GHC.Float
+       , module GHC.Num
+       , module GHC.Real
+       , integerToBounded
+       , integerToNatural
+       )
+        where
+
+import Numeric
+
+import Data.Bits (toIntegralSized)
+import Data.Function (($))
+import Data.Int (Int, Int16, Int32, Int64, Int8)
+import GHC.Float (Double (..), Float (..), Floating (acos, acosh, asin, asinh, atan, atanh, cos, cosh, exp, logBase, pi, sin, sinh, sqrt, tan, tanh, (**)))
+import GHC.Num (Integer, Num (..), subtract)
+import GHC.Real (Fractional (..), Integral (..), Ratio, Rational, Real (..), RealFrac (..),
+                 denominator, even, fromIntegral, gcd, lcm, numerator, odd, realToFrac, (^), (^^))
+import Numeric.Natural (Natural)
+
+import Relude.Base (Bounded (..), (<), (<=), (>))
+import Relude.Bool (otherwise)
+import Relude.Monad (Maybe (..))
+
+
+-- $setup
+-- import Relude.Monad (Maybe (..))
+--
+-- >>> integerToBounded 42
+-- Just 42
+--
+-- integerToBounded :: forall a. (Integral a, Bounded a) => Integer -> Maybe a
+integerToBounded :: Int -> Maybe Int
+integerToBounded n | n < minBound = Nothing
+                   | n > maxBound = Nothing
+                   | otherwise    = Just n
+
+-- >>> integerToNatural (-1)
+-- Nothing
+--
+-- >>> integerToNatural 0
+-- Nothing
+--
+-- >>> integerToNatural 10
+-- Just 10
+integerToNatural :: Integer -> Maybe Natural
+integerToNatural n | n <= 0    = Nothing
+                   | otherwise = Just $ fromIntegral n

--- a/src/Relude/Unsafe.hs
+++ b/src/Relude/Unsafe.hs
@@ -28,8 +28,8 @@ module Relude.Unsafe
 import Data.List (head, init, last, tail, (!!))
 import Data.Maybe (fromJust)
 
-import Relude.Base (Int)
 import Relude.Function (flip)
+import Relude.Numeric (Int)
 
 -- | Similar to '!!' but with flipped arguments.
 at :: Int -> [a] -> a


### PR DESCRIPTION
Resolves #125 

I'm not sure about the signature of `integerToBounded`, I cannot make it work. I get
`Couldn't match type ‘a’ with ‘Integer’`. Is there a language extension I can use to have this type of polymorphism?

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [x] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
