### PR TITLE
[#136] Add HLint rules for Extra modules

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2995,6 +2995,49 @@
     name: '''liftIO'' is not needed'
     rhs: putLBSLn
 - hint:
+    lhs: fmap (bimap f g)
+    note: Use `bimapF` from `Relude.Extra.Bifunctor`
+    rhs: bimapF f g
+- hint:
+    lhs: bimap f g <$> x
+    note: Use `bimapF` from `Relude.Extra.Bifunctor`
+    rhs: bimapF f g x
+- hint:
+    lhs: fmap (first f)
+    note: Use `firstF` from `Relude.Extra.Bifunctor`
+    rhs: firstF f
+- hint:
+    lhs: fmap . first
+    note: Use `firstF` from `Relude.Extra.Bifunctor`
+    rhs: firstF
+- hint:
+    lhs: fmap (second f)
+    note: Use `secondF` from `Relude.Extra.Bifunctor`
+    rhs: secondF f
+- hint:
+    lhs: fmap . second
+    note: Use `secondF` from `Relude.Extra.Bifunctor`
+    rhs: secondF
+- hint:
+    lhs: '[minBound .. maxBound]'
+    note: Use `universe` from `Relude.Extra.Enum`
+    rhs: universe
+- hint:
+    lhs: succ
+    note: '`succ` from `Prelude` is a pure function but it may throw exception. Consider
+      using `next` from `Relude.Extra.Enum` instead.'
+    rhs: next
+- hint:
+    lhs: pred
+    note: '`pred` from `Prelude` is a pure function but it may throw exception. Consider
+      using `prec` from `Relude.Extra.Enum` instead.'
+    rhs: prec
+- hint:
+    lhs: toEnum
+    note: '`toEnum` from `Prelude` is a pure function but it may throw exception.
+      Consider using `safeToEnum` from `Relude.Extra.Enum` instead.'
+    rhs: safeToEnum
+- hint:
     lhs: fmap (,a) (f a)
     note: Use `traverseToFst` from `Relude.Extra.Tuple`
     rhs: traverseToFst f a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The changelog is available [on GitHub][2].
   Reexport `Ap` from `Data.Monoid`. Change definition of `foldMapA` to use `Ap`.
 * [#140](https://github.com/kowainik/relude/issues/140):
   Improve text of custom compile-time error messages for `elem` functions.
+* [#136](https://github.com/kowainik/relude/issues/136):
+  Cover `Relude.Extra.*` modules with custom HLint rules.
 * Improve documentation for `One` typeclass and add tests.
 * Support ghc-8.6.3 and ghc-8.4.4.
   Drop support for ghc-8.6.1 and ghc-8.4.3.

--- a/hlint/hlint.dhall
+++ b/hlint/hlint.dhall
@@ -887,6 +887,20 @@ in [ rule.Arguments { arguments =
    -- Extra
    ------------
 
+   -- Bifunctor
+   , hintNote "fmap (bimap f g)" "bimapF f g"   "Use `bimapF` from `Relude.Extra.Bifunctor`"
+   , hintNote "bimap f g <$> x"  "bimapF f g x" "Use `bimapF` from `Relude.Extra.Bifunctor`"
+   , hintNote "fmap (first f)" "firstF f" "Use `firstF` from `Relude.Extra.Bifunctor`"
+   , hintNote "fmap . first"   "firstF"   "Use `firstF` from `Relude.Extra.Bifunctor`"
+   , hintNote "fmap (second f)" "secondF f" "Use `secondF` from `Relude.Extra.Bifunctor`"
+   , hintNote "fmap . second"   "secondF"   "Use `secondF` from `Relude.Extra.Bifunctor`"
+
+   -- Enum
+   , hintNote "[minBound .. maxBound]" "universe" "Use `universe` from `Relude.Extra.Enum`"
+   , hintNote "succ" "next" "`succ` from `Prelude` is a pure function but it may throw exception. Consider using `next` from `Relude.Extra.Enum` instead."
+   , hintNote "pred" "prec" "`pred` from `Prelude` is a pure function but it may throw exception. Consider using `prec` from `Relude.Extra.Enum` instead."
+   , hintNote "toEnum" "safeToEnum" "`toEnum` from `Prelude` is a pure function but it may throw exception. Consider using `safeToEnum` from `Relude.Extra.Enum` instead."
+
    -- Tuple
    , hintNote "fmap (,a) (f a)"         "traverseToFst f a" "Use `traverseToFst` from `Relude.Extra.Tuple`"
    , hintNote "fmap (flip (,) a) (f a)" "traverseToFst f a" "Use `traverseToFst` from `Relude.Extra.Tuple`"


### PR DESCRIPTION
Resolves #136

Turns out not much can be covered. We have a lot of custom things (like CallStack, newtype, Foldable1, etc.) which doesn't have analogues in `base`.