### PR TITLE
[#172] Add Semigroup and Monoid instances to Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog is available [on GitHub][2].
 * [#155](https://github.com/kowainik/relude/issues/155):
   Implement `Relude.Extra.Foldable` module.
 * Re-export `GHC.Float.atan2`.
+* Add `Monoid` and `Semigroup` instances for `Validation` type
 
 ## 0.5.0 — Mar 18, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The changelog is available [on GitHub][2].
 * [#155](https://github.com/kowainik/relude/issues/155):
   Implement `Relude.Extra.Foldable` module.
 * Re-export `GHC.Float.atan2`.
-* Add `Monoid` and `Semigroup` instances for `Validation` type
+* [#172](https://github.com/kowainik/relude/issues/172):
+  Add `Monoid` and `Semigroup` instances for `Validation` type
 
 ## 0.5.0 — Mar 18, 2019
 

--- a/src/Relude/Extra/Validation.hs
+++ b/src/Relude/Extra/Validation.hs
@@ -52,10 +52,14 @@ Failure ["Not correct"]
 -}
 
 instance (Semigroup e, Semigroup a) => Semigroup (Validation e a) where
-    x <> y = (<>) <$> x <*> y
+    (<>) :: Validation e a -> Validation e a -> Validation e a
+    (<>) = liftA2 (<>)
+    {-# INLINE (<>) #-}
 
 instance (Semigroup e, Monoid a) => Monoid (Validation e a) where
+    mempty :: Validation e a
     mempty = Success mempty
+    {-# INLINE mempty #-}
 
 {- | __Examples__
 
@@ -75,10 +79,10 @@ Failure ["Not correct"]
 >>> c *> d *> b
 Failure ["Not correct","Not correct either"]
 
->>> (+) <$> a <*> b
+>>> liftA2 (+) a b
 Success 8
 
->>> (+) <$> a <*> c
+>>> liftA2 (+) a c
 Failure ["Not correct"]
 -}
 instance Semigroup e => Applicative (Validation e) where

--- a/src/Relude/Extra/Validation.hs
+++ b/src/Relude/Extra/Validation.hs
@@ -8,19 +8,75 @@ Copyright:  (c) 2014 Chris Allen, Edward Kmett
 License:    MIT
 Maintainer: Kowainik <xrom.xkov@gmail.com>
 
-Monoidal 'Validation' sibling to 'Either'.
+'Validation' is a monoidal sibling to 'Either'. Use 'Validation' on operations that
+might fail with multiple errors that you want to preserve.
 -}
 
+
 module Relude.Extra.Validation
-       ( Validation(..)
+       (
+       -- * How to use
+       -- $use
+         Validation(..)
        , validationToEither
        , eitherToValidation
        ) where
 
 import Relude
 
--- $setup
--- >>> :set -XTypeApplications -XOverloadedStrings
+{- | $setup
+>>> :set -XTypeApplications -XOverloadedStrings
+-}
+
+{- $use
+
+Take for example a type @Computer@ that needs to be validated:
+
+>>> data Computer = Computer { ram :: Int, cpus :: Int } deriving (Eq, Show)
+
+You can validate that the computer has a minimum of 16 GB of RAM:
+
+>>> :{
+validateRam :: Int -> Validation [Text] Int
+validateRam ram
+ | ram >= 16 = Success ram
+ | otherwise = Failure ["Not enough RAM"]
+:}
+
+and that the processor has at least two CPUs:
+
+>>> :{
+validateCpus :: Int -> Validation [Text] Int
+validateCpus cpus
+ | cpus >= 2 = Success cpus
+ | otherwise = Failure ["Not enough CPUs"]
+:}
+
+You can use these functions with the 'Applicative' instance of the 'Validation'
+type to construct a validated @Computer@. You will get either (pun intended) a
+valid @Computer@ or the errors that prevent it from being considered valid.
+
+Like so:
+
+>>> :{
+mkComputer :: Int -> Int -> Validation [Text] Computer
+mkComputer ram cpus = Computer <$> validateRam ram <*> validateCpus cpus
+:}
+
+Using @mkComputer@ we get a @Success Computer@ or a list with all possible errors:
+
+>>> mkComputer 16 2
+Success (Computer {ram = 16, cpus = 2})
+
+>>> mkComputer 16 1
+Failure ["Not enough CPUs"]
+
+>>> mkComputer 15 2
+Failure ["Not enough RAM"]
+
+>>> mkComputer 15 1
+Failure ["Not enough RAM","Not enough CPUs"]
+-}
 
 -- | 'Validation' is 'Either' with a Left that is a 'Monoid'
 data Validation e a

--- a/src/Relude/Extra/Validation.hs
+++ b/src/Relude/Extra/Validation.hs
@@ -39,7 +39,7 @@ instance Functor (Validation e) where
     _ <$ Failure e = Failure e
     {-# INLINE (<$) #-}
 
-{- | __Examples __
+{- | __Examples__
 >>> let a = Success "First success." :: Validation [Text] Text
 >>> let b = Success " Second success." :: Validation [Text] Text
 >>> let c = Failure ["Not correct"] :: Validation [Text] Text


### PR DESCRIPTION
Resolves #172.

- [x] Removes `liftA2` custom definition.
- [x] Adds `Semigroup` and `Monoid` instances to `Validation` type.
- [ ] Improves documentation for `Validation` module with use cases.

## Checklist:

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
