### PR TITLE
[#177] Walk through all modules and think carefully about SPECIALIZE/…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,56 @@
-*.sw[pon]
-.stack-work
+### Haskell
 dist
-dist-newstyle/
-.cabal-sandbox
-cabal.sandbox.config
-.ghc.environment.*
-
-*.hi
+dist-*
+cabal-dev
 *.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+*.prof
+*.aux
+*.hp
+*.eventlog
+.virtualenv
+.hsenv
+.hpc
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+cabal.project.local
+.ghc.environment.*
+.HTF/
+# Stack
+.stack-work/
+stack.yaml.lock
+# Nix
+result
+
+### IDE/support
+# Vim
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+*~
+tags
+
+# IntellijIDEA
+.idea/
+.ideaHaskellLib/
+*.iml
+
+# Atom
+.haskell-ghc-mod.json
+
+# VS
+.vscode/
+
+# Emacs
+*#
+.dir-locals.el
 TAGS
 
-*~
-
-.dir-locals.el
-*.html
-
-*.liquid
-
+# other
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 `relude` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
-## Unreleased: 0.6.0
+## Unreleased: 0.6.0.0
+
 * [#155](https://github.com/kowainik/relude/issues/155):
   Implement `Relude.Extra.Foldable` module.
 * Re-export `GHC.Float.atan2`.
 * [#172](https://github.com/kowainik/relude/issues/172):
   Add `Monoid` and `Semigroup` instances for `Validation` type
+* [#177](https://github.com/kowainik/relude/issues/177):
+  Improve usage of performance pragmas.
 * [#178](https://github.com/kowainik/relude/issues/178):
   Made `die` be polymorphic in its return type.
 

--- a/relude.cabal
+++ b/relude.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                relude
-version:             0.5.0
+version:             0.6.0.0
 synopsis:            Custom prelude from Kowainik
 description:
     == Goals
@@ -79,7 +79,8 @@ common common-options
     ghc-options:       -fhide-source-paths
 
   default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
+  default-extensions:  InstanceSigs
+                       NoImplicitPrelude
                        OverloadedStrings
                        ScopedTypeVariables
                        TypeApplications
@@ -169,9 +170,9 @@ test-suite relude-test
   build-depends:       relude
                      , bytestring
                      , text
-                     , hedgehog >= 0.6
+                     , hedgehog ^>= 1.0
                      , tasty
-                     , tasty-hedgehog
+                     , tasty-hedgehog ^>= 1.0
 
   ghc-options:         -threaded
 

--- a/src/Relude/Applicative.hs
+++ b/src/Relude/Applicative.hs
@@ -31,6 +31,7 @@ import Control.Applicative (Alternative (..), Applicative (..), Const (..), ZipL
 -- Just ()
 pass :: Applicative f => f ()
 pass = pure ()
+{-# INLINE pass #-}
 
 {- | For chaining applicative operations in forward applications using '(&)'
 Named version of the '<**>' operator, which is '<*>' but flipped

--- a/src/Relude/Base.hs
+++ b/src/Relude/Base.hs
@@ -64,7 +64,7 @@ import Data.Proxy (Proxy (..))
 import Data.Typeable (Typeable)
 import Data.Void (Void, absurd, vacuous)
 
-import GHC.Base (String, asTypeOf, ord, seq, ($!))
+import GHC.Base (asTypeOf, ord, seq, ($!))
 import GHC.Enum (Bounded (..), Enum (..), boundedEnumFrom, boundedEnumFromThen)
 import GHC.Generics (Generic)
 import GHC.Show (Show)

--- a/src/Relude/Bool/Guard.hs
+++ b/src/Relude/Bool/Guard.hs
@@ -17,9 +17,10 @@ module Relude.Bool.Guard
        , (||^)
        ) where
 
+import Relude.Applicative (Applicative (..))
 import Relude.Bool.Reexport (Bool (..), guard, unless, when)
 import Relude.Function (flip)
-import Relude.Monad (Monad, MonadPlus, return, (>>=))
+import Relude.Monad (Monad, MonadPlus, (>>=))
 
 -- $setup
 -- >>> import Relude.Applicative (pure)
@@ -82,7 +83,7 @@ guardM f = f >>= guard
 -- >>> Just False &&^ error "Shouldn't be evaluated"
 -- Just False
 (&&^) :: Monad m => m Bool -> m Bool -> m Bool
-(&&^) e1 e2 = ifM e1 e2 (return False)
+(&&^) e1 e2 = ifM e1 e2 (pure False)
 {-# INLINE (&&^) #-}
 
 -- | Monadic version of 'Data.Bool.(||)' operator.
@@ -90,5 +91,5 @@ guardM f = f >>= guard
 -- >>> Just True ||^ error "Shouldn't be evaluated"
 -- Just True
 (||^) :: Monad m => m Bool -> m Bool -> m Bool
-(||^) e1 e2 = ifM e1 (return True) e2
+(||^) e1 e2 = ifM e1 (pure True) e2
 {-# INLINE (||^) #-}

--- a/src/Relude/Container/One.hs
+++ b/src/Relude/Container/One.hs
@@ -69,6 +69,7 @@ this container)
 class One x where
     -- | Type of single element of the structure.
     type OneItem x
+
     -- | Create a list, map, 'Text', etc from a single element.
     one :: OneItem x -> x
 
@@ -84,6 +85,8 @@ prop> length (one @[Int] x) == 1
 -}
 instance One [a] where
     type OneItem [a] = a
+
+    one :: a -> [a]
     one = (:[])
     {-# INLINE one #-}
 
@@ -97,6 +100,8 @@ prop> length (one @(NonEmpty Int) x) == 1
 -}
 instance One (NE.NonEmpty a) where
     type OneItem (NE.NonEmpty a) = a
+
+    one :: a -> NE.NonEmpty a
     one = (NE.:|[])
     {-# INLINE one #-}
 
@@ -109,6 +114,8 @@ prop> length (one @(Seq Int) x) == 1
 -}
 instance One (SEQ.Seq a) where
     type OneItem (SEQ.Seq a) = a
+
+    one :: a -> SEQ.Seq a
     one = SEQ.singleton
     {-# INLINE one #-}
 
@@ -123,6 +130,8 @@ prop> Text.length (one x) == 1
 -}
 instance One T.Text where
     type OneItem T.Text = Char
+
+    one :: Char -> T.Text
     one = T.singleton
     {-# INLINE one #-}
 
@@ -135,6 +144,8 @@ prop> LText.length (one x) == 1
 -}
 instance One TL.Text where
     type OneItem TL.Text = Char
+
+    one :: Char -> TL.Text
     one = TL.singleton
     {-# INLINE one #-}
 
@@ -147,6 +158,8 @@ prop> ByteString.length (one x) == 1
 -}
 instance One BS.ByteString where
     type OneItem BS.ByteString = Word8
+
+    one :: Word8 -> BS.ByteString
     one = BS.singleton
     {-# INLINE one #-}
 
@@ -159,6 +172,8 @@ prop> LByteString.length (one x) == 1
 -}
 instance One BSL.ByteString where
     type OneItem BSL.ByteString = Word8
+
+    one :: Word8 -> BSL.ByteString
     one = BSL.singleton
     {-# INLINE one #-}
 
@@ -173,6 +188,8 @@ prop> length (one @(Map Int String) x) == 1
 -}
 instance One (Map k v) where
     type OneItem (Map k v) = (k, v)
+
+    one :: (k, v) -> Map k v
     one = uncurry M.singleton
     {-# INLINE one #-}
 
@@ -185,6 +202,8 @@ prop> length (one @(HashMap Int String) x) == 1
 -}
 instance Hashable k => One (HashMap k v) where
     type OneItem (HashMap k v) = (k, v)
+
+    one :: (k, v) -> HashMap k v
     one = uncurry HM.singleton
     {-# INLINE one #-}
 
@@ -197,6 +216,8 @@ prop> length (one @(IntMap String) x) == 1
 -}
 instance One (IntMap v) where
     type OneItem (IntMap v) = (Int, v)
+
+    one :: (Int, v) -> IntMap v
     one = uncurry IM.singleton
     {-# INLINE one #-}
 
@@ -209,8 +230,10 @@ fromList [42]
 
 prop> length (one @(Set Int) x) == 1
 -}
-instance One (Set v) where
-    type OneItem (Set v) = v
+instance One (Set a) where
+    type OneItem (Set a) = a
+
+    one :: a -> Set a
     one = Set.singleton
     {-# INLINE one #-}
 
@@ -221,8 +244,10 @@ fromList [42]
 
 prop> length (one @(HashSet Int) x) == 1
 -}
-instance Hashable v => One (HashSet v) where
-    type OneItem (HashSet v) = v
+instance Hashable a => One (HashSet a) where
+    type OneItem (HashSet a) = a
+
+    one :: a -> HashSet a
     one = HashSet.singleton
     {-# INLINE one #-}
 
@@ -235,5 +260,7 @@ prop> IntSet.size (one x) == 1
 -}
 instance One IntSet where
     type OneItem IntSet = Int
+
+    one :: Int -> IntSet
     one = IS.singleton
     {-# INLINE one #-}

--- a/src/Relude/Debug.hs
+++ b/src/Relude/Debug.hs
@@ -41,8 +41,8 @@ import Data.Data (Data)
 import GHC.Exts (RuntimeRep, TYPE)
 
 import Relude.Applicative (Applicative)
-import Relude.Base (Bounded, Enum, Eq, Generic, HasCallStack, Ord, Show, String, Typeable)
-import Relude.String (Read, Text, toString)
+import Relude.Base (Bounded, Enum, Eq, Generic, HasCallStack, Ord, Show, Typeable)
+import Relude.String (Read, String, Text, toString)
 
 import qualified Debug.Trace as Debug
 import qualified Prelude

--- a/src/Relude/DeepSeq.hs
+++ b/src/Relude/DeepSeq.hs
@@ -20,25 +20,34 @@ module Relude.DeepSeq
 
 import Control.DeepSeq (NFData (..), deepseq, force, ($!!))
 
-import Relude.Base (seq)
+import Relude.Base (IO, seq)
 import Relude.Function ((.))
 import Relude.Monad (MonadIO, liftIO, (<$!>))
 
 import qualified Control.Exception.Base (evaluate)
 
+
 -- | Lifted alias for 'Control.Exception.Base.evaluate' with clearer name.
 evaluateWHNF :: MonadIO m => a -> m a
 evaluateWHNF = liftIO . Control.Exception.Base.evaluate
+{-# INLINE evaluateWHNF #-}
+{-# SPECIALIZE evaluateWHNF :: a -> IO a #-}
 
 -- | Like 'evaluateWNHF' but discards value.
 evaluateWHNF_ :: MonadIO m => a -> m ()
 evaluateWHNF_ what = (`seq` ()) <$!> evaluateWHNF what
+{-# INLINE evaluateWHNF_ #-}
+{-# SPECIALIZE evaluateWHNF_ :: a -> IO () #-}
 
 -- | Alias for @evaluateWHNF . force@ with clearer name.
 evaluateNF :: (NFData a, MonadIO m) => a -> m a
 evaluateNF = evaluateWHNF . force
+{-# INLINE evaluateNF #-}
+{-# SPECIALIZE evaluateNF :: NFData a => a -> IO a #-}
 
 -- | Alias for @evaluateWHNF . rnf@. Similar to 'evaluateNF'
 -- but discards resulting value.
 evaluateNF_ :: (NFData a, MonadIO m) => a -> m ()
 evaluateNF_ = evaluateWHNF . rnf
+{-# INLINE evaluateNF_ #-}
+{-# SPECIALIZE evaluateNF_ :: NFData a => a -> IO () #-}

--- a/src/Relude/Exception.hs
+++ b/src/Relude/Exception.hs
@@ -32,8 +32,10 @@ import Relude.Monad (Maybe (..))
 
 import qualified Control.Exception as E (displayException, throw, toException)
 
--- | Type that represents exceptions used in cases when a particular codepath
--- is not meant to be ever executed, but happens to be executed anyway.
+
+{- | Type that represents exceptions used in cases when a particular codepath is
+not meant to be ever executed, but happens to be executed anyway.
+-}
 data Bug = Bug SomeException CallStack
     deriving (Show)
 

--- a/src/Relude/Extra/Bifunctor.hs
+++ b/src/Relude/Extra/Bifunctor.hs
@@ -23,6 +23,7 @@ module Relude.Extra.Bifunctor
 
 import Relude
 
+
 {- | Fmaps functions for nested bifunctor. Short for @fmap (bimap f g)@.
 
 >>> bimapF not length $ Just (False, ['a', 'b'])
@@ -30,6 +31,7 @@ Just (True,2)
 -}
 bimapF  :: (Functor f, Bifunctor p) => (a -> c) -> (b -> d) -> f (p a b) -> f (p c d)
 bimapF f g = fmap (bimap f g)
+{-# INLINE bimapF #-}
 
 {- | Short for @fmap . first@.
 
@@ -38,6 +40,7 @@ Just (True,"ab")
 -}
 firstF  :: (Functor f, Bifunctor p) => (a -> c) -> f (p a b) -> f (p c b)
 firstF = fmap . first
+{-# INLINE firstF #-}
 
 {- | Short for @fmap . second@.
 
@@ -46,3 +49,4 @@ Just (False,2)
 -}
 secondF  :: (Functor f, Bifunctor p) => (b -> d) -> f (p a b) -> f (p a d)
 secondF = fmap . second
+{-# INLINE secondF #-}

--- a/src/Relude/Extra/Enum.hs
+++ b/src/Relude/Extra/Enum.hs
@@ -21,6 +21,7 @@ import Relude
 
 import qualified Data.Map.Strict as M
 
+
 -- $setup
 -- >>> :set -XTypeApplications
 
@@ -34,6 +35,7 @@ import qualified Data.Map.Strict as M
 -}
 universe :: (Bounded a, Enum a) => [a]
 universe = [minBound .. maxBound]
+{-# INLINE universe #-}
 
 {- | @inverseMap f@ creates a function that is the inverse of a given function
 @f@. It does so by constructing 'M.Map' for every value @f a@. The
@@ -60,6 +62,7 @@ inverseMap f = \k -> M.lookup k dict
 
     univ :: [a]
     univ = universe
+{-# INLINE inverseMap #-}
 
 {- | Like 'succ', but doesn't fail on 'maxBound'. Instead it returns 'minBound'.
 
@@ -74,6 +77,7 @@ next  :: (Eq a, Bounded a, Enum a) => a -> a
 next e
     | e == maxBound = minBound
     | otherwise     = succ e
+{-# INLINE next #-}
 
 {- | Like 'pred', but doesn't fail on 'minBound'. Instead it returns 'maxBound'.
 
@@ -88,6 +92,7 @@ prec  :: (Eq a, Bounded a, Enum a) => a -> a
 prec e
     | e == minBound = maxBound
     | otherwise     = pred e
+{-# INLINE prec #-}
 
 {- | Returns 'Nothing' if given 'Int' outside range.
 
@@ -102,3 +107,4 @@ Nothing
 -}
 safeToEnum :: forall a . (Bounded a, Enum a) => Int -> Maybe a
 safeToEnum i = guard (fromEnum @a minBound <= i && i <= fromEnum @a maxBound) *> Just (toEnum i)
+{-# INLINE safeToEnum #-}

--- a/src/Relude/Extra/Foldable.hs
+++ b/src/Relude/Extra/Foldable.hs
@@ -14,6 +14,7 @@ module Relude.Extra.Foldable
 
 import Relude
 
+
 -- $setup
 -- >>> :set -XOverloadedStrings
 
@@ -34,4 +35,3 @@ foldlSC f = flip $ foldr go id
         Left l  -> l
         Right r -> k r
 {-# INLINE foldlSC #-}
-

--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE InstanceSigs     #-}
 {-# LANGUAGE TypeApplications #-}
 
 {- |
@@ -20,6 +19,7 @@ import Data.Functor.Product (Product (..))
 import Data.Functor.Sum (Sum (..))
 
 import qualified Data.Semigroup as SG
+
 
 {- | The class of foldable data structures that cannot be empty.
 -}
@@ -93,7 +93,6 @@ instance Foldable1 NonEmpty where
     foldMap1 f (a :| b : bs) = f a <> foldMap1 f (b :| bs)
     {-# INLINE foldMap1 #-}
 
-
     toNonEmpty :: NonEmpty a -> NonEmpty a
     toNonEmpty = id
     {-# INLINE toNonEmpty #-}
@@ -109,7 +108,6 @@ instance Foldable1 NonEmpty where
     minimum1 = foldl1' min
     {-# INLINE maximum1 #-}
     {-# INLINE minimum1 #-}
-
 
 instance Foldable1 Identity where
     foldMap1 :: Semigroup m => (a -> m) -> Identity a -> m

--- a/src/Relude/Extra/Group.hs
+++ b/src/Relude/Extra/Group.hs
@@ -19,6 +19,7 @@ import Relude.Extra.Map
 
 import Data.List.NonEmpty ((<|))
 
+
 {- | Groups elements using results of the given function as keys.
 
 >>> groupBy even [1..6] :: HashMap Bool (NonEmpty Int)

--- a/src/Relude/Extra/Lens.hs
+++ b/src/Relude/Extra/Lens.hs
@@ -165,6 +165,7 @@ module Relude.Extra.Lens
 
 import Relude
 
+
 {- | The monomorphic lenses which don't change the type of the container (or of
 the value inside). It has a 'Functor' constraint, and since both 'Const' and
 'Identity' are functors, it can be used whenever a getter or a setter is needed.

--- a/src/Relude/Extra/Newtype.hs
+++ b/src/Relude/Extra/Newtype.hs
@@ -22,6 +22,7 @@ module Relude.Extra.Newtype
 
 import Relude
 
+
 -- $setup
 -- >>> :set -XTypeApplications
 -- >>> import Data.Semigroup (Max (..))

--- a/src/Relude/Extra/Tuple.hs
+++ b/src/Relude/Extra/Tuple.hs
@@ -20,6 +20,7 @@ module Relude.Extra.Tuple
 
 import Relude
 
+
 {- | Creates a tuple by pairing something with itself.
 
 >>> dupe "foo"
@@ -33,7 +34,6 @@ dupe a = (a, a)
 
 {- | Apply a function, with the result in the fst slot,
 and the value in the other.
-
 
 A dual to 'mapToSnd'
 

--- a/src/Relude/Extra/Type.hs
+++ b/src/Relude/Extra/Type.hs
@@ -31,6 +31,7 @@ import Type.Reflection (Typeable, typeRep)
 import Data.Typeable (Typeable, typeRep)
 #endif
 
+
 -- $setup
 -- >>> :set -XDataKinds -XTypeOperators
 
@@ -55,7 +56,6 @@ typeName = show (typeRep (Proxy @a))
 #endif
 {-# INLINE typeName #-}
 
-infixr 5 ++
 {- | Concatenates type-level lists.
 
 >>> :kind! '[ 'Just 5, 'Nothing] ++ '[ 'Just 3, 'Nothing, 'Just 1]
@@ -66,6 +66,7 @@ infixr 5 ++
 '[] ++ '[ 'Just 3, 'Nothing, 'Just 1] :: [Maybe Nat]
 = '[ 'Just 3, 'Nothing, 'Just 1]
 -}
+infixr 5 ++
 type family (++) (xs :: [k]) (ys :: [k]) :: [k] where
     '[]       ++ ys = ys
     (x ': xs) ++ ys = x ': xs ++ ys

--- a/src/Relude/Extra/Validation.hs
+++ b/src/Relude/Extra/Validation.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE CPP          #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE LambdaCase   #-}
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE LambdaCase #-}
 
 {- |
 Copyright:  (c) 2014 Chris Allen, Edward Kmett
@@ -23,6 +22,7 @@ module Relude.Extra.Validation
        ) where
 
 import Relude
+
 
 {- | $setup
 >>> :set -XTypeApplications -XOverloadedStrings

--- a/src/Relude/Foldable/Fold.hs
+++ b/src/Relude/Foldable/Fold.hs
@@ -183,6 +183,8 @@ andM = go . toList
     go (p:ps) = do
         q <- p
         if q then go ps else pure False
+{-# INLINEABLE andM #-}
+{-# SPECIALIZE andM :: [IO Bool] -> IO Bool #-}
 
 {- | Monadic version of 'F.or'.
 
@@ -200,6 +202,8 @@ orM = go . toList
     go (p:ps) = do
         q <- p
         if q then pure True else go ps
+{-# INLINEABLE orM #-}
+{-# SPECIALIZE orM  :: [IO Bool] -> IO Bool #-}
 
 {- | Monadic version of 'F.all'.
 
@@ -217,6 +221,8 @@ allM p = go . toList
     go (x:xs) = do
         q <- p x
         if q then go xs else pure False
+{-# INLINEABLE allM #-}
+{-# SPECIALIZE allM :: (a -> IO Bool) -> [a] -> IO Bool #-}
 
 {- | Monadic  version of 'F.any'.
 
@@ -234,11 +240,8 @@ anyM p = go . toList
     go (x:xs) = do
         q <- p x
         if q then pure True else go xs
-
-{-# SPECIALIZE andM :: [IO Bool] -> IO Bool #-}
-{-# SPECIALIZE orM  :: [IO Bool] -> IO Bool #-}
+{-# INLINEABLE anyM #-}
 {-# SPECIALIZE anyM :: (a -> IO Bool) -> [a] -> IO Bool #-}
-{-# SPECIALIZE allM :: (a -> IO Bool) -> [a] -> IO Bool #-}
 
 ----------------------------------------------------------------------------
 -- Type level tricks

--- a/src/Relude/Lifted/Concurrent.hs
+++ b/src/Relude/Lifted/Concurrent.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
 
 {- |
 Copyright:  (c) 2016 Stephen Diehl
@@ -38,10 +38,11 @@ module Relude.Lifted.Concurrent
 import Control.Concurrent.MVar (MVar)
 import Control.Concurrent.STM.TVar (TVar)
 import Control.Monad.STM (STM)
-import Control.Monad.Trans (MonadIO, liftIO)
-import Data.Bool (Bool)
-import Data.Function (($), (.))
-import Data.Maybe (Maybe)
+
+import Relude.Base (IO)
+import Relude.Bool (Bool)
+import Relude.Function (($), (.))
+import Relude.Monad (Maybe, MonadIO (..))
 
 import qualified Control.Concurrent.MVar as CCM (newEmptyMVar, newMVar, putMVar, readMVar, swapMVar,
                                                  takeMVar, tryPutMVar, tryReadMVar, tryTakeMVar)
@@ -57,46 +58,55 @@ import qualified Control.Monad.STM as STM (atomically)
 newEmptyMVar :: MonadIO m => m (MVar a)
 newEmptyMVar = liftIO CCM.newEmptyMVar
 {-# INLINE newEmptyMVar #-}
+{-# SPECIALIZE newEmptyMVar :: IO (MVar a) #-}
 
 -- | Lifted to 'MonadIO' version of 'CCM.newMVar'.
 newMVar :: MonadIO m => a -> m (MVar a)
 newMVar = liftIO . CCM.newMVar
 {-# INLINE newMVar #-}
+{-# SPECIALIZE newMVar :: a -> IO (MVar a) #-}
 
 -- | Lifted to 'MonadIO' version of 'CCM.putMVar'.
 putMVar :: MonadIO m => MVar a -> a -> m ()
 putMVar m a = liftIO $ CCM.putMVar m a
 {-# INLINE putMVar #-}
+{-# SPECIALIZE putMVar :: MVar a -> a -> IO () #-}
 
 -- | Lifted to 'MonadIO' version of 'CCM.readMVar'.
 readMVar :: MonadIO m => MVar a -> m a
 readMVar = liftIO . CCM.readMVar
 {-# INLINE readMVar #-}
+{-# SPECIALIZE readMVar :: MVar a -> IO a #-}
 
 -- | Lifted to 'MonadIO' version of 'CCM.swapMVar'.
 swapMVar :: MonadIO m => MVar a -> a -> m a
 swapMVar m v = liftIO $ CCM.swapMVar m v
 {-# INLINE swapMVar #-}
+{-# SPECIALIZE swapMVar :: MVar a -> a -> IO a #-}
 
 -- | Lifted to 'MonadIO' version of 'CCM.takeMVar'.
 takeMVar :: MonadIO m => MVar a -> m a
 takeMVar = liftIO . CCM.takeMVar
 {-# INLINE takeMVar #-}
+{-# SPECIALIZE takeMVar :: MVar a -> IO a #-}
 
 -- | Lifted to 'MonadIO' version of 'CCM.tryPutMVar'.
 tryPutMVar :: MonadIO m => MVar a -> a -> m Bool
 tryPutMVar m v = liftIO $ CCM.tryPutMVar m v
 {-# INLINE tryPutMVar #-}
+{-# SPECIALIZE tryPutMVar :: MVar a -> a -> IO Bool #-}
 
 -- | Lifted to 'MonadIO' version of 'CCM.tryReadMVar'.
 tryReadMVar :: MonadIO m => MVar a -> m (Maybe a)
 tryReadMVar = liftIO . CCM.tryReadMVar
 {-# INLINE tryReadMVar #-}
+{-# SPECIALIZE tryReadMVar :: MVar a -> IO (Maybe a) #-}
 
 -- | Lifted to 'MonadIO' version of 'CCM.tryTakeMVar'.
 tryTakeMVar :: MonadIO m => MVar a -> m (Maybe a)
 tryTakeMVar = liftIO . CCM.tryTakeMVar
 {-# INLINE tryTakeMVar #-}
+{-# SPECIALIZE tryTakeMVar :: MVar a -> IO (Maybe a) #-}
 
 ----------------------------------------------------------------------------
 -- Lifted STM
@@ -106,13 +116,16 @@ tryTakeMVar = liftIO . CCM.tryTakeMVar
 atomically :: MonadIO m => STM a -> m a
 atomically = liftIO . STM.atomically
 {-# INLINE atomically #-}
+{-# SPECIALIZE atomically :: STM a -> IO a #-}
 
 -- | Lifted to 'MonadIO' version of 'STM.newTVarIO'.
 newTVarIO :: MonadIO m => a -> m (TVar a)
 newTVarIO = liftIO . STM.newTVarIO
 {-# INLINE newTVarIO #-}
+{-# SPECIALIZE newTVarIO :: a -> IO (TVar a) #-}
 
 -- | Lifted to 'MonadIO' version of 'STM.readTVarIO'.
 readTVarIO :: MonadIO m => TVar a -> m a
 readTVarIO = liftIO . STM.readTVarIO
 {-# INLINE readTVarIO #-}
+{-# SPECIALIZE readTVarIO :: TVar a -> IO a #-}

--- a/src/Relude/Lifted/Exit.hs
+++ b/src/Relude/Lifted/Exit.hs
@@ -23,22 +23,19 @@ import System.Exit (ExitCode)
 
 import qualified System.Exit as XIO
 
+
 -- | Lifted version of 'System.Exit.exitWith'.
 exitWith :: MonadIO m => ExitCode -> m a
 exitWith a = liftIO (XIO.exitWith a)
-{-# INLINE exitWith #-}
 
 -- | Lifted version of 'System.Exit.exitFailure'.
 exitFailure :: MonadIO m => m a
 exitFailure = liftIO XIO.exitFailure
-{-# INLINE exitFailure #-}
 
 -- | Lifted version of 'System.Exit.exitSuccess'.
 exitSuccess :: MonadIO m => m a
 exitSuccess = liftIO XIO.exitSuccess
-{-# INLINE exitSuccess #-}
 
 -- | Lifted version of 'System.Exit.die'.
 die :: MonadIO m => String -> m a
 die err = liftIO (XIO.die err)
-{-# INLINE die #-}

--- a/src/Relude/Lifted/File.hs
+++ b/src/Relude/Lifted/File.hs
@@ -14,9 +14,10 @@ module Relude.Lifted.File
        , appendFile
        ) where
 
-import Relude.Base (FilePath, IO, String)
+import Relude.Base (FilePath, IO)
 import Relude.Function ((.))
 import Relude.Monad.Reexport (MonadIO (..))
+import Relude.String (String)
 
 import qualified System.IO as IO
 

--- a/src/Relude/Lifted/IORef.hs
+++ b/src/Relude/Lifted/IORef.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE Trustworthy #-}
 
 {- |
 Copyright:  (c) 2016 Stephen Diehl
@@ -26,45 +26,56 @@ import Control.Monad.Trans (MonadIO, liftIO)
 import Data.Function (($), (.))
 import Data.IORef (IORef)
 
+import Relude.Base (IO)
+
 import qualified Data.IORef as Ref (atomicModifyIORef, atomicModifyIORef', atomicWriteIORef,
                                     modifyIORef, modifyIORef', newIORef, readIORef, writeIORef)
+
 
 -- | Lifted version of 'Ref.newIORef'.
 newIORef :: MonadIO m => a -> m (IORef a)
 newIORef = liftIO . Ref.newIORef
 {-# INLINE newIORef #-}
+{-# SPECIALIZE newIORef :: a -> IO (IORef a) #-}
 
 -- | Lifted version of 'Ref.readIORef'.
 readIORef :: MonadIO m => IORef a -> m a
 readIORef = liftIO . Ref.readIORef
 {-# INLINE readIORef #-}
+{-# SPECIALIZE readIORef :: IORef a -> IO a #-}
 
 -- | Lifted version of 'Ref.writeIORef'.
 writeIORef :: MonadIO m => IORef a -> a -> m ()
 writeIORef ref what = liftIO $ Ref.writeIORef ref what
 {-# INLINE writeIORef #-}
+{-# SPECIALIZE writeIORef :: IORef a -> a -> IO () #-}
 
 -- | Lifted version of 'Ref.modifyIORef'.
 modifyIORef :: MonadIO m => IORef a -> (a -> a) -> m ()
 modifyIORef ref how = liftIO $ Ref.modifyIORef ref how
 {-# INLINE modifyIORef #-}
+{-# SPECIALIZE modifyIORef :: IORef a -> (a -> a) -> IO () #-}
 
 -- | Lifted version of 'Ref.modifyIORef''.
 modifyIORef' :: MonadIO m => IORef a -> (a -> a) -> m ()
 modifyIORef' ref how = liftIO $ Ref.modifyIORef' ref how
 {-# INLINE modifyIORef' #-}
+{-# SPECIALIZE modifyIORef' :: IORef a -> (a -> a) -> IO () #-}
 
 -- | Lifted version of 'Ref.atomicModifyIORef'.
 atomicModifyIORef :: MonadIO m => IORef a -> (a -> (a, b)) -> m b
 atomicModifyIORef ref how = liftIO $ Ref.atomicModifyIORef ref how
 {-# INLINE atomicModifyIORef #-}
+{-# SPECIALIZE atomicModifyIORef :: IORef a -> (a -> (a, b)) -> IO b #-}
 
 -- | Lifted version of 'Ref.atomicModifyIORef''.
 atomicModifyIORef' :: MonadIO m => IORef a -> (a -> (a, b)) -> m b
 atomicModifyIORef' ref how = liftIO $ Ref.atomicModifyIORef' ref how
 {-# INLINE atomicModifyIORef' #-}
+{-# SPECIALIZE atomicModifyIORef' :: IORef a -> (a -> (a, b)) -> IO b #-}
 
 -- | Lifted version of 'Ref.atomicWriteIORef'.
 atomicWriteIORef :: MonadIO m => IORef a -> a -> m ()
 atomicWriteIORef ref what = liftIO $ Ref.atomicWriteIORef ref what
 {-# INLINE atomicWriteIORef #-}
+{-# SPECIALIZE atomicWriteIORef :: IORef a -> a -> IO () #-}

--- a/src/Relude/Lifted/Terminal.hs
+++ b/src/Relude/Lifted/Terminal.hs
@@ -15,13 +15,14 @@ module Relude.Lifted.Terminal
        , putStrLn
        ) where
 
-import Relude.Base (IO, Show, String)
+import Relude.Base (IO, Show)
 import Relude.Function ((.))
 import Relude.Monad.Reexport (MonadIO (..))
-import Relude.String.Reexport (Text)
+import Relude.String.Reexport (String, Text)
 
 import qualified Data.Text.IO as TIO
 import qualified System.IO as IO (print, putStr, putStrLn)
+
 
 -- | Lifted version of 'Data.Text.getLine'.
 getLine :: MonadIO m => m Text

--- a/src/Relude/List/NonEmpty.hs
+++ b/src/Relude/List/NonEmpty.hs
@@ -22,6 +22,7 @@ import Relude.Functor (fmap)
 import Relude.List.Reexport (NonEmpty (..), nonEmpty)
 import Relude.Monad (Maybe (..), Monad (..))
 
+
 -- $setup
 -- >>> import Relude
 
@@ -41,7 +42,6 @@ viaNonEmpty f = fmap f . nonEmpty
 >>> whenNotNull [] $ \(b :| _) -> print (not b)
 >>> whenNotNull [False,True] $ \(b :| _) -> print (not b)
 True
-
 -}
 whenNotNull :: Applicative f => [a] -> (NonEmpty a -> f ()) -> f ()
 whenNotNull []     _ = pass

--- a/src/Relude/Monad/Either.hs
+++ b/src/Relude/Monad/Either.hs
@@ -38,7 +38,7 @@ import Data.Maybe (Maybe (..), maybe)
 import Relude.Applicative (pure)
 import Relude.Function ((.))
 import Relude.Monad.Reexport (Either (..), MonadFail (..), either)
-import Relude.String (IsString, fromString)
+import Relude.String (IsString, String, fromString)
 
 #if MIN_VERSION_base(4,10,0)
 import Data.Either (fromLeft, fromRight)
@@ -64,10 +64,12 @@ fromRight b (Left _)  = b
 fromRight _ (Right b) = b
 #endif
 
+
 -- $setup
 -- >>> import Relude.Bool (Bool (..))
 
 instance IsString str => MonadFail (Either str) where
+    fail :: String -> Either str a
     fail = Left . fromString
 
 -- | Maps left part of 'Either' to 'Maybe'.
@@ -78,6 +80,7 @@ instance IsString str => MonadFail (Either str) where
 -- Nothing
 leftToMaybe :: Either l r -> Maybe l
 leftToMaybe = either Just (const Nothing)
+{-# INLINE leftToMaybe #-}
 
 -- | Maps right part of 'Either' to 'Maybe'.
 --
@@ -87,6 +90,7 @@ leftToMaybe = either Just (const Nothing)
 -- Just "aba"
 rightToMaybe :: Either l r -> Maybe r
 rightToMaybe = either (const Nothing) Just
+{-# INLINE rightToMaybe #-}
 
 -- | Maps 'Maybe' to 'Either' wrapping default value into 'Left'.
 --
@@ -96,6 +100,7 @@ rightToMaybe = either (const Nothing) Just
 -- Left True
 maybeToRight :: l -> Maybe r -> Either l r
 maybeToRight l = maybe (Left l) Right
+{-# INLINE maybeToRight #-}
 
 -- | Maps 'Maybe' to 'Either' wrapping default value into 'Right'.
 --
@@ -105,6 +110,7 @@ maybeToRight l = maybe (Left l) Right
 -- Right True
 maybeToLeft :: r -> Maybe l -> Either l r
 maybeToLeft r = maybe (Right r) Left
+{-# INLINE maybeToLeft #-}
 
 -- | Applies given action to 'Either' content if 'Left' is given and returns
 -- the result. In case of 'Right' the default value will be returned.

--- a/src/Relude/Monad/Maybe.hs
+++ b/src/Relude/Monad/Maybe.hs
@@ -23,6 +23,7 @@ module Relude.Monad.Maybe
 import Relude.Applicative (Applicative, pass, pure)
 import Relude.Monad.Reexport (Maybe (..), Monad (..), fromMaybe)
 
+
 -- $setup
 -- >>> import Relude
 

--- a/src/Relude/Monad/Trans.hs
+++ b/src/Relude/Monad/Trans.hs
@@ -78,7 +78,6 @@ executingState :: s -> State s a -> s
 executingState s st = snd (usingState s st)
 {-# INLINE executingState #-}
 
-
 -- | Lift a 'Maybe' to the 'MaybeT' monad
 hoistMaybe  :: Applicative m => Maybe a -> MaybeT m a
 hoistMaybe m = MaybeT (pure m)

--- a/src/Relude/Monoid.hs
+++ b/src/Relude/Monoid.hs
@@ -55,6 +55,7 @@ import Relude.String.Reexport (Read)
 -- []
 maybeToMonoid :: Monoid m => Maybe m -> m
 maybeToMonoid = fromMaybe mempty
+{-# INLINE maybeToMonoid #-}
 
 #if !MIN_VERSION_base(4,12,0)
 -- | This data type witnesses the lifting of a 'Monoid' into an

--- a/src/Relude/Nub.hs
+++ b/src/Relude/Nub.hs
@@ -43,20 +43,23 @@ import Prelude ((.))
 
 import qualified Data.Set as Set
 
+
 {- | Like 'Prelude.nub' but runs in \( O(n \log n) \)  time and requires 'Ord'.
 
 >>> ordNub [3, 3, 3, 2, 2, -1, 1]
 [3,2,-1,1]
 
 -}
-ordNub :: (Ord a) => [a] -> [a]
+ordNub :: forall a . (Ord a) => [a] -> [a]
 ordNub = go Set.empty
   where
+    go :: Set.Set a -> [a] -> [a]
     go _ []     = []
     go s (x:xs) =
       if x `Set.member` s
       then go s xs
       else x : go (Set.insert x s) xs
+{-# INLINEABLE ordNub #-}
 
 {- | Like 'Prelude.nub' but runs in \( O(n \log_{16} n) \)  time and requires 'Hashable'.
 
@@ -64,14 +67,16 @@ ordNub = go Set.empty
 [3,2,-1,1]
 
 -}
-hashNub :: (Eq a, Hashable a) => [a] -> [a]
+hashNub :: forall a . (Eq a, Hashable a) => [a] -> [a]
 hashNub = go HashSet.empty
   where
+    go :: HashSet.HashSet a -> [a] -> [a]
     go _ []     = []
     go s (x:xs) =
       if x `HashSet.member` s
       then go s xs
       else x : go (HashSet.insert x s) xs
+{-# INLINEABLE hashNub #-}
 
 {- | Like 'ordNub' runs in \( O(n \log n) \)  but also sorts a list.
 
@@ -81,6 +86,7 @@ hashNub = go HashSet.empty
 -}
 sortNub :: (Ord a) => [a] -> [a]
 sortNub = Set.toList . Set.fromList
+{-# INLINE sortNub #-}
 
 {- | Like 'hashNub' runs in \( O(n \log_{16} n) \) but has better performance; it doesn't save the order.
 
@@ -90,3 +96,4 @@ sortNub = Set.toList . Set.fromList
 -}
 unstableNub :: (Eq a, Hashable a) => [a] -> [a]
 unstableNub = HashSet.toList . HashSet.fromList
+{-# INLINE unstableNub #-}

--- a/src/Relude/Numeric.hs
+++ b/src/Relude/Numeric.hs
@@ -25,7 +25,7 @@ import Data.Int (Int, Int16, Int32, Int64, Int8)
 import Data.Word (Word, Word16, Word32, Word64, Word8, byteSwap16, byteSwap32, byteSwap64)
 import GHC.Base (maxInt, minInt)
 import GHC.Float (Double (..), Float (..), Floating (acos, acosh, asin, asinh, atan, atanh, cos, cosh, exp, logBase, pi, sin, sinh, sqrt, tan, tanh, (**)),
-                  RealFloat (atan2, floatRadix, floatDigits, floatRange, decodeFloat, encodeFloat, isNaN, isInfinite, isDenormalized, isNegativeZero, isIEEE))
+                  RealFloat (atan2, decodeFloat, encodeFloat, floatDigits, floatRadix, floatRange, isDenormalized, isIEEE, isInfinite, isNaN, isNegativeZero))
 import GHC.Num (Integer, Num (..), subtract)
 import GHC.Real (Fractional (..), Integral (..), Ratio, Rational, Real (..), RealFrac (..),
                  denominator, even, fromIntegral, gcd, lcm, numerator, odd, realToFrac, (^), (^^))
@@ -54,7 +54,8 @@ integerToBounded :: forall a. (Integral a, Bounded a) => Integer -> Maybe a
 integerToBounded n
     | n < toInteger (minBound @a) = Nothing
     | n > toInteger (maxBound @a) = Nothing
-    | otherwise                    = Just (fromIntegral n)
+    | otherwise                   = Just (fromIntegral n)
+{-# INLINE integerToBounded #-}
 
 {- | Tranforms an integer number to a natural.
 Only non-negative integers are considered natural, everything else will return `Nothing`.
@@ -71,5 +72,6 @@ Just 10
 -}
 integerToNatural :: Integer -> Maybe Natural
 integerToNatural n
-    | n < 0    = Nothing
+    | n < 0     = Nothing
     | otherwise = Just $ fromIntegral n
+{-# INLINE integerToNatural #-}

--- a/src/Relude/String/Conversion.hs
+++ b/src/Relude/String/Conversion.hs
@@ -46,7 +46,6 @@ import Data.String (String)
 import Relude.Functor ((<$>))
 import Relude.String.Reexport (ByteString, IsString, Read, Text, fromString)
 
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -98,75 +97,142 @@ class ConvertUtf8 a b where
     -}
     decodeUtf8Strict :: b -> Either T.UnicodeException a
 
-instance ConvertUtf8 String B.ByteString where
+instance ConvertUtf8 String ByteString where
+    encodeUtf8 :: String -> ByteString
     encodeUtf8 = T.encodeUtf8 . T.pack
+    {-# INLINE encodeUtf8 #-}
+
+    decodeUtf8 :: ByteString -> String
     decodeUtf8 = T.unpack . T.decodeUtf8
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: ByteString -> Either T.UnicodeException String
     decodeUtf8Strict = (T.unpack <$>) . decodeUtf8Strict
+    {-# INLINE decodeUtf8Strict #-}
 
-instance ConvertUtf8 T.Text B.ByteString where
+instance ConvertUtf8 Text ByteString where
+    encodeUtf8 :: Text -> ByteString
     encodeUtf8 = T.encodeUtf8
-    decodeUtf8 = T.decodeUtf8With T.lenientDecode
-    decodeUtf8Strict = T.decodeUtf8'
+    {-# INLINE encodeUtf8 #-}
 
-instance ConvertUtf8 LT.Text B.ByteString where
+    decodeUtf8 :: ByteString -> Text
+    decodeUtf8 = T.decodeUtf8With T.lenientDecode
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: ByteString -> Either T.UnicodeException Text
+    decodeUtf8Strict = T.decodeUtf8'
+    {-# INLINE decodeUtf8Strict #-}
+
+instance ConvertUtf8 LText ByteString where
+    encodeUtf8 :: LText -> ByteString
     encodeUtf8 = LB.toStrict . encodeUtf8
+    {-# INLINE encodeUtf8 #-}
+
+    decodeUtf8 :: ByteString -> LText
     decodeUtf8 = LT.decodeUtf8With T.lenientDecode . LB.fromStrict
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: ByteString -> Either T.UnicodeException LText
     decodeUtf8Strict = decodeUtf8Strict . LB.fromStrict
+    {-# INLINE decodeUtf8Strict #-}
+
 -- | Converting 'String' to 'LB.ByteString' might be a slow operation.
 -- Consider using lazy bytestring at first place.
-instance ConvertUtf8 String LB.ByteString where
+instance ConvertUtf8 String LByteString where
+    encodeUtf8 :: String -> LByteString
     encodeUtf8 = LT.encodeUtf8 . LT.pack
+    {-# INLINE encodeUtf8 #-}
+
+    decodeUtf8 :: LByteString -> String
     decodeUtf8 = LT.unpack . LT.decodeUtf8
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: LByteString -> Either T.UnicodeException String
     decodeUtf8Strict = (T.unpack <$>) . decodeUtf8Strict
+    {-# INLINE decodeUtf8Strict #-}
 
-instance ConvertUtf8 T.Text LB.ByteString where
+instance ConvertUtf8 Text LByteString where
+    encodeUtf8 :: Text -> LByteString
     encodeUtf8 = LB.fromStrict . T.encodeUtf8
-    decodeUtf8 = T.decodeUtf8With T.lenientDecode . LB.toStrict
-    decodeUtf8Strict = T.decodeUtf8' . LB.toStrict
+    {-# INLINE encodeUtf8 #-}
 
-instance ConvertUtf8 LT.Text LB.ByteString where
+    decodeUtf8 :: LByteString -> Text
+    decodeUtf8 = T.decodeUtf8With T.lenientDecode . LB.toStrict
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: LByteString -> Either T.UnicodeException Text
+    decodeUtf8Strict = T.decodeUtf8' . LB.toStrict
+    {-# INLINE decodeUtf8Strict #-}
+
+instance ConvertUtf8 LText LByteString where
+    encodeUtf8 :: LText -> LByteString
     encodeUtf8 = LT.encodeUtf8
+    {-# INLINE encodeUtf8 #-}
+
+    decodeUtf8 :: LByteString -> LText
     decodeUtf8 = LT.decodeUtf8With T.lenientDecode
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: LByteString -> Either T.UnicodeException LText
     decodeUtf8Strict = LT.decodeUtf8'
+    {-# INLINE decodeUtf8Strict #-}
 
 -- | Type class for converting other strings to 'T.Text'.
 class ToText a where
-    toText :: a -> T.Text
+    toText :: a -> Text
 
 instance ToText String where
+    toText :: String -> Text
     toText = T.pack
+    {-# INLINE toText #-}
 
-instance ToText T.Text where
+instance ToText Text where
+    toText :: Text -> Text
     toText = id
+    {-# INLINE toText #-}
 
-instance ToText LT.Text where
+instance ToText LText where
+    toText :: LText -> Text
     toText = LT.toStrict
+    {-# INLINE toText #-}
 
 -- | Type class for converting other strings to 'LT.Text'.
 class ToLText a where
-    toLText :: a -> LT.Text
+    toLText :: a -> LText
 
 instance ToLText String where
+    toLText :: String -> LText
     toLText = LT.pack
+    {-# INLINE toLText #-}
 
-instance ToLText T.Text where
+instance ToLText Text where
+    toLText :: Text -> LText
     toLText = LT.fromStrict
+    {-# INLINE toLText #-}
 
 instance ToLText LT.Text where
+    toLText :: LText -> LText
     toLText = id
+    {-# INLINE toLText #-}
 
 -- | Type class for converting other strings to 'String'.
 class ToString a where
     toString :: a -> String
 
 instance ToString String where
+    toString :: String -> String
     toString = id
+    {-# INLINE toString #-}
 
-instance ToString T.Text where
+instance ToString Text where
+    toString :: Text -> String
     toString = T.unpack
+    {-# INLINE toString #-}
 
-instance ToString LT.Text where
+instance ToString LText where
+    toString :: LText -> String
     toString = LT.unpack
+    {-# INLINE toString #-}
 
 -- | Polymorhpic version of 'Text.Read.readEither'.
 --
@@ -176,20 +242,21 @@ instance ToString LT.Text where
 -- Left "Prelude.read: no parse"
 readEither :: (ToString a, Read b) => a -> Either Text b
 readEither = first toText . Text.Read.readEither . toString
+{-# INLINEABLE readEither #-}
 
 -- | Generalized version of 'Prelude.show'.
 show :: forall b a . (Show.Show a, IsString b) => a -> b
 show x = fromString (Show.show x)
+{-# INLINE show #-}
 {-# SPECIALIZE show :: Show.Show  a => a -> Text  #-}
 {-# SPECIALIZE show :: Show.Show  a => a -> LText  #-}
 {-# SPECIALIZE show :: Show.Show  a => a -> ByteString  #-}
 {-# SPECIALIZE show :: Show.Show  a => a -> LByteString  #-}
 {-# SPECIALIZE show :: Show.Show  a => a -> String  #-}
 
-
 -- | Type class for lazy-strict conversions.
 class LazyStrict l s | l -> s, s -> l where
-    toLazy :: s -> l
+    toLazy   :: s -> l
     toStrict :: l -> s
 
 -- | Alias for 'toStrict' function.
@@ -207,13 +274,19 @@ fromStrict = toLazy
 {-# SPECIALIZE fromStrict :: Text -> LText  #-}
 
 instance LazyStrict LByteString ByteString where
+    toLazy :: ByteString -> LByteString
     toLazy = LB.fromStrict
     {-# INLINE toLazy #-}
+
+    toStrict :: LByteString -> ByteString
     toStrict = LB.toStrict
     {-# INLINE toStrict #-}
 
 instance LazyStrict LText Text where
+    toLazy :: Text -> LText
     toLazy = LT.fromStrict
     {-# INLINE toLazy #-}
+
+    toStrict :: LText -> Text
     toStrict = LT.toStrict
     {-# INLINE toStrict #-}

--- a/src/Relude/String/Reexport.hs
+++ b/src/Relude/String/Reexport.hs
@@ -23,7 +23,7 @@ module Relude.String.Reexport
        ) where
 
 import Data.ByteString (ByteString)
-import Data.String (IsString (..))
+import Data.String (IsString (..), String)
 import Data.Text (Text, lines, unlines, unwords, words)
 import Data.Text.Encoding (decodeUtf8', decodeUtf8With)
 import Data.Text.Encoding.Error (OnDecodeError, OnError, UnicodeException, lenientDecode,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,4 @@
-resolver: lts-13.20
-
-extra-deps:
-  - tasty-hedgehog-0.2.0.0
+resolver: lts-14.1
 
 nix:
   packages: [binutils, gmp]

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -16,4 +16,8 @@ import Test.DocTest (doctest)
 main :: IO ()
 main = do
     sourceFiles <- glob "src/**/*.hs"
-    doctest $ "-XNoImplicitPrelude" : sourceFiles
+    doctest
+        $ "-XInstanceSigs"
+        : "-XNoImplicitPrelude"
+        : "-XScopedTypeVariables"
+        : sourceFiles


### PR DESCRIPTION
…INLINABLE/INLINE pragmas

Resolves #177

I had a discussion recently about `INLINE`, `SPECIALIZE` and `INLINEABLE` pragmas. So I now understand these pragmas better. But the rules when to use them are still vague. So I tried to use my judgement to specify these pragmas where appropriately.

This PR does the following:

1. Add missing pragmas in all modules
2. Adds `InstanceSigs` and signatures in some places
3. Update to modern `.gitignore`
4. Move `String` type to `Relude.String` for consistency 
5. Minor stylistic changes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
