### PR TITLE
[#164] Reexport ShortByteString

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2660,6 +2660,21 @@
     name: Use 'ByteString' from Relude
     rhs: ByteString
 - warn:
+    lhs: Data.ByteString.Short.ShortByteString
+    note: '''ShortByteString'' is already exported from Relude'
+    name: Use 'ShortByteString' from Relude
+    rhs: ShortByteString
+- warn:
+    lhs: Data.ByteString.Short.toShort
+    note: '''toShort'' is already exported from Relude'
+    name: Use 'toShort' from Relude
+    rhs: toShort
+- warn:
+    lhs: Data.ByteString.Short.fromShort
+    note: '''fromShort'' is already exported from Relude'
+    name: Use 'fromShort' from Relude
+    rhs: fromShort
+- warn:
     lhs: Data.String.IsString
     note: '''IsString'' is already exported from Relude'
     name: Use 'IsString' from Relude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The changelog is available [on GitHub][2].
   Improve usage of performance pragmas.
 * [#178](https://github.com/kowainik/relude/issues/178):
   Made `die` be polymorphic in its return type.
+* [#164](https://github.com/kowainik/relude/issues/164):
+  Reexport `ShortByteString`, `toShort`/`fromShort` functions.
 
 ## 0.5.0 — Mar 18, 2019
 

--- a/README.md
+++ b/README.md
@@ -518,8 +518,8 @@ First time:
 $ cabal new-install dhall-json
 ```
 
-Dhall 3.0.0 is required, so make sure that the previous command installed
-dhall-json >= 1.2.4.
+Dhall 9.0.0 is required, so make sure that the previous command installed
+dhall-json >= 1.4.0.
 
 To generate `hlint` file:
 

--- a/hlint/hlint.dhall
+++ b/hlint/hlint.dhall
@@ -6,8 +6,8 @@ in let warnSimple     = warn.warnSimple
 in let warnNote       = warn.warnNote
 in let hintNote       = warn.hintNote
 in let hintNoteOp     = warn.hintNoteOp
-in let rule           = constructors ./Rule.dhall
-in [ rule.Arguments { arguments =
+in let Rule = ./Rule.dhall
+in [ Rule.Arguments { arguments =
        [ "-XConstraintKinds"
        , "-XDeriveGeneric"
        , "-XGeneralizedNewtypeDeriving"
@@ -25,9 +25,9 @@ in [ rule.Arguments { arguments =
    -- Ignore
    -------------
    -- There's no 'head' in Relude
-   , rule.Ignore {ignore = {name = "Use head"}}
+   , Rule.Ignore {ignore = {name = "Use head"}}
    -- We have 'whenJust' for this
-   , rule.Ignore {ignore = {name = "Use Foldable.forM_"}}
+   , Rule.Ignore {ignore = {name = "Use Foldable.forM_"}}
 
    -------------
    -- Relude specific
@@ -805,6 +805,9 @@ in [ rule.Arguments { arguments =
 
    -- String
    , warnReexport "ByteString" "Data.ByteString"
+   , warnReexport "ShortByteString" "Data.ByteString.Short"
+   , warnReexport "toShort"         "Data.ByteString.Short"
+   , warnReexport "fromShort"       "Data.ByteString.Short"
    , warnReexport "IsString"   "Data.String"
    , warnReexport "fromString" "Data.String"
    , warnReexport "Text"    "Data.Text"

--- a/hlint/warn.dhall
+++ b/hlint/warn.dhall
@@ -1,9 +1,8 @@
 let Rule = ./Rule.dhall
-in let rule = constructors Rule
 in let warnSimple
     : Text -> Text -> Rule
     = \(lhsTxt : Text) -> \(rhsTxt : Text) ->
-        rule.Warn
+        Rule.Warn
         { warn =
             { name = None Text
             , lhs = "${lhsTxt}"
@@ -15,7 +14,7 @@ in let warnSimple
 in let warnNote
     : Text -> Text -> Text -> Rule
     = \(lhsTxt : Text) -> \(rhsTxt : Text) -> \(n : Text) ->
-        rule.Warn {warn =
+        Rule.Warn {warn =
             { name = None Text
             , lhs = "${lhsTxt}"
             , rhs = "${rhsTxt}"
@@ -26,7 +25,7 @@ in let warnNote
 in let warnReexport
     : Text -> Text -> Rule
     = \(f : Text) -> \(mod : Text) ->
-        rule.Warn
+        Rule.Warn
         { warn =
             { name = Some "Use '${f}' from Relude"
             , lhs = "${mod}.${f}"
@@ -37,7 +36,7 @@ in let warnReexport
 
 in let warnReexportOp : Text -> Text -> Rule
     = \(f : Text) -> \(mod : Text) ->
-        rule.Warn
+        Rule.Warn
         { warn =
             { name = Some "Use '${f}' from Relude"
             , lhs = "(${mod}.${f})"
@@ -49,7 +48,7 @@ in let warnReexportOp : Text -> Text -> Rule
 in let warnLifted
     : Text -> Text -> Rule
     =  \(f : Text) -> \(args : Text) ->
-        rule.Warn
+        Rule.Warn
         { warn =
             { name = Some "'liftIO' is not needed"
             , lhs = "(liftIO (${f} ${args}))"
@@ -61,7 +60,7 @@ in let warnLifted
 in let hintNote
     : Text -> Text -> Text -> Rule
     = \(lhsTxt : Text) -> \(rhsTxt : Text) -> \(n : Text) ->
-        rule.Hint
+        Rule.Hint
         { hint =
             { lhs = "${lhsTxt}"
             , rhs = "${rhsTxt}"

--- a/src/Relude/Container/One.hs
+++ b/src/Relude/Container/One.hs
@@ -30,6 +30,7 @@ import qualified Data.Sequence as SEQ
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Short as SBS
 
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
@@ -47,6 +48,7 @@ import qualified Data.Set as Set
 -- >>> import qualified Data.HashMap.Strict as HashMap
 -- >>> import qualified Data.Text as Text
 -- >>> import qualified Data.ByteString as ByteString
+-- >>> import qualified Data.ByteString.Short as ShortByteString
 -- >>> import qualified Data.Text.Lazy as LText
 -- >>> import qualified Data.ByteString.Lazy as LByteString
 
@@ -175,6 +177,20 @@ instance One BSL.ByteString where
 
     one :: Word8 -> BSL.ByteString
     one = BSL.singleton
+    {-# INLINE one #-}
+
+{- | Create singleton 'SBS.ShortByteString'.
+
+>>> one 97 :: ShortByteString
+"a"
+
+prop> ShortByteString.length (one x) == 1
+-}
+instance One SBS.ShortByteString where
+    type OneItem SBS.ShortByteString = Word8
+
+    one :: Word8 -> SBS.ShortByteString
+    one x = SBS.pack [x]
     {-# INLINE one #-}
 
 -- Maps

--- a/src/Relude/String/Conversion.hs
+++ b/src/Relude/String/Conversion.hs
@@ -180,28 +180,41 @@ instance ConvertUtf8 LText LByteString where
 
 instance ConvertUtf8 String ShortByteString where
     encodeUtf8 :: String -> ShortByteString
-    encodeUtf8 = toShort . T.encodeUtf8 . T.pack
+    encodeUtf8 = toShort . encodeUtf8
     {-# INLINE encodeUtf8 #-}
 
     decodeUtf8 :: ShortByteString -> String
-    decodeUtf8 = T.unpack . T.decodeUtf8 . fromShort
+    decodeUtf8 = decodeUtf8 . fromShort
     {-# INLINE decodeUtf8 #-}
 
     decodeUtf8Strict :: ShortByteString -> Either T.UnicodeException String
-    decodeUtf8Strict = (T.unpack <$>) . decodeUtf8Strict . fromShort
+    decodeUtf8Strict = decodeUtf8Strict . fromShort
     {-# INLINE decodeUtf8Strict #-}
 
 instance ConvertUtf8 Text ShortByteString where
     encodeUtf8 :: Text -> ShortByteString
-    encodeUtf8 = toShort . T.encodeUtf8
+    encodeUtf8 = toShort . encodeUtf8
     {-# INLINE encodeUtf8 #-}
 
     decodeUtf8 :: ShortByteString -> Text
-    decodeUtf8 = T.decodeUtf8With T.lenientDecode . fromShort
+    decodeUtf8 = decodeUtf8 . fromShort
     {-# INLINE decodeUtf8 #-}
 
     decodeUtf8Strict :: ShortByteString -> Either T.UnicodeException Text
-    decodeUtf8Strict = T.decodeUtf8' . fromShort
+    decodeUtf8Strict = decodeUtf8Strict . fromShort
+    {-# INLINE decodeUtf8Strict #-}
+
+instance ConvertUtf8 LText ShortByteString where
+    encodeUtf8 :: LText -> ShortByteString
+    encodeUtf8 = toShort . encodeUtf8
+    {-# INLINE encodeUtf8 #-}
+
+    decodeUtf8 :: ShortByteString -> LText
+    decodeUtf8 = decodeUtf8 . fromShort
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: ShortByteString -> Either T.UnicodeException LText
+    decodeUtf8Strict = decodeUtf8Strict . fromShort
     {-# INLINE decodeUtf8Strict #-}
 
 -- | Type class for converting other strings to 'T.Text'.

--- a/src/Relude/String/Conversion.hs
+++ b/src/Relude/String/Conversion.hs
@@ -44,7 +44,8 @@ import Data.Function (id, (.))
 import Data.String (String)
 
 import Relude.Functor ((<$>))
-import Relude.String.Reexport (ByteString, IsString, Read, Text, fromString)
+import Relude.String.Reexport (ByteString, IsString, Read, ShortByteString, Text, fromShort,
+                               fromString, toShort)
 
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text as T
@@ -175,6 +176,32 @@ instance ConvertUtf8 LText LByteString where
 
     decodeUtf8Strict :: LByteString -> Either T.UnicodeException LText
     decodeUtf8Strict = LT.decodeUtf8'
+    {-# INLINE decodeUtf8Strict #-}
+
+instance ConvertUtf8 String ShortByteString where
+    encodeUtf8 :: String -> ShortByteString
+    encodeUtf8 = toShort . T.encodeUtf8 . T.pack
+    {-# INLINE encodeUtf8 #-}
+
+    decodeUtf8 :: ShortByteString -> String
+    decodeUtf8 = T.unpack . T.decodeUtf8 . fromShort
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: ShortByteString -> Either T.UnicodeException String
+    decodeUtf8Strict = (T.unpack <$>) . decodeUtf8Strict . fromShort
+    {-# INLINE decodeUtf8Strict #-}
+
+instance ConvertUtf8 Text ShortByteString where
+    encodeUtf8 :: Text -> ShortByteString
+    encodeUtf8 = toShort . T.encodeUtf8
+    {-# INLINE encodeUtf8 #-}
+
+    decodeUtf8 :: ShortByteString -> Text
+    decodeUtf8 = T.decodeUtf8With T.lenientDecode . fromShort
+    {-# INLINE decodeUtf8 #-}
+
+    decodeUtf8Strict :: ShortByteString -> Either T.UnicodeException Text
+    decodeUtf8Strict = T.decodeUtf8' . fromShort
     {-# INLINE decodeUtf8Strict #-}
 
 -- | Type class for converting other strings to 'T.Text'.

--- a/src/Relude/String/Reexport.hs
+++ b/src/Relude/String/Reexport.hs
@@ -5,7 +5,8 @@ Copyright:  (c) 2016 Stephen Diehl
 License:    MIT
 Maintainer: Kowainik <xrom.xkov@gmail.com>
 
-Reexports functions to work with 'Text' and 'ByteString' types.
+Reexports functions to work with 'Text', 'ByteString'
+and 'ShortByteString' types.
 -}
 
 module Relude.String.Reexport
@@ -19,10 +20,16 @@ module Relude.String.Reexport
        , module Text.Read
 
          -- * ByteString
-       , module Data.ByteString
+       , ByteString
+
+         -- * ShortByteString
+       , ShortByteString
+       , toShort
+       , fromShort
        ) where
 
 import Data.ByteString (ByteString)
+import Data.ByteString.Short (ShortByteString, fromShort, toShort)
 import Data.String (IsString (..), String)
 import Data.Text (Text, lines, unlines, unwords, words)
 import Data.Text.Encoding (decodeUtf8', decodeUtf8With)


### PR DESCRIPTION
Resolves #164
and part of #148 

I've decided to export `toShort` and `fromShort` functions as well. I checked hoogle and it seems that there is no much functions with such names, so there should be no collisions. But let me know if it's better to not reexport them.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [x] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [x] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [x] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [x] I've added the `[ci skip]` text to the docs-only related commit's name.
