### PR TITLE
Implement `asumMap` and `foldMapA` by coercing `foldMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog is available [on GitHub][2].
 
 * [#191](https://github.com/kowainik/relude/pull/191):
   Implement `asumMap` and `foldMapA` by coercing `foldMap`.
+  BREAKING CHANGE: Reorder type parameters to `asumMap`.
 * Use `$>` instead of `*>` and `pure` where possible.
 * [#167](https://github.com/kowainik/relude/issues/167):
   Rename functions `prec`/`prev`, `dupe`/`dup`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog is available [on GitHub][2].
 
 ## Unreleased: 0.6.0.0
 
+* [#191](https://github.com/kowainik/relude/pull/191):
+  Implement `asumMap` and `foldMapA` by coercing `foldMap`.
 * Use `$>` instead of `*>` and `pure` where possible.
 * [#167](https://github.com/kowainik/relude/issues/167):
   Rename functions `prec`/`prev`, `dupe`/`dup`.

--- a/src/Relude/Foldable/Fold.hs
+++ b/src/Relude/Foldable/Fold.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE ExplicitForAll       #-}
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
@@ -40,11 +39,11 @@ module Relude.Foldable.Fold
 import GHC.TypeLits (ErrorMessage (..), Symbol, TypeError)
 
 import Relude.Applicative (Alternative, Applicative (..), pure)
-import Relude.Base (Constraint, Eq, IO, Type, ($!))
+import Relude.Base (Constraint, Eq, IO, Type, coerce, ($!))
 import Relude.Bool (Bool (..))
 import Relude.Container.Reexport (HashSet, Set)
 import Relude.Foldable.Reexport (Foldable (..))
-import Relude.Function (flip, (.))
+import Relude.Function (flip)
 import Relude.Monad.Reexport (Monad (..))
 import Relude.Monoid (Alt (..), Ap (..), Monoid (..), Semigroup)
 import Relude.Numeric (Num (..))
@@ -73,8 +72,8 @@ flipfoldl' f = foldl' (flip f)
 >>> asumMap (\x -> if x > 2 then Just x else Nothing) [1..4]
 Just 3
 -}
-asumMap :: (Foldable f, Alternative m) => (a -> m b) -> f a -> m b
-asumMap f = getAlt . foldMap (Alt . f)
+asumMap :: forall f m a b . (Foldable f, Alternative m) => (a -> m b) -> f a -> m b
+asumMap = coerce (foldMap :: (a -> Alt m b) -> f a -> Alt m b)
 {-# INLINE asumMap #-}
 
 {- | Polymorphic version of @concatMapA@ function.
@@ -83,7 +82,7 @@ asumMap f = getAlt . foldMap (Alt . f)
 Just [1,1,1,2,2,2,3,3,3]
 -}
 foldMapA :: forall b m f a . (Semigroup b, Monoid b, Applicative m, Foldable f) => (a -> m b) -> f a -> m b
-foldMapA f = getAp . foldMap (Ap . f)
+foldMapA = coerce (foldMap :: (a -> Ap m b) -> f a -> Ap m b)
 {-# INLINE foldMapA #-}
 
 {- | Polymorphic version of @concatMapM@ function.

--- a/src/Relude/Foldable/Fold.hs
+++ b/src/Relude/Foldable/Fold.hs
@@ -72,7 +72,7 @@ flipfoldl' f = foldl' (flip f)
 >>> asumMap (\x -> if x > 2 then Just x else Nothing) [1..4]
 Just 3
 -}
-asumMap :: forall f m a b . (Foldable f, Alternative m) => (a -> m b) -> f a -> m b
+asumMap :: forall b m f a . (Foldable f, Alternative m) => (a -> m b) -> f a -> m b
 asumMap = coerce (foldMap :: (a -> Alt m b) -> f a -> Alt m b)
 {-# INLINE asumMap #-}
 


### PR DESCRIPTION
This is how `fmapDefault` and `foldMapDefault` look in base,
and is useful for the same reasons.

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
