### PR TITLE
Use `mapToFst` instead of `zip` to improve list fusion in `inverseMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog is available [on GitHub][2].
 ## Unreleased: 0.6.0.0
 
 * [#194](https://github.com/kowainik/relude/pull/194):
-  Use `mapToFst` instead of `zip` to improve list fusion.
+  Use `mapToFst` instead of `zip` to improve list fusion in `inverseMap`.
 * [#191](https://github.com/kowainik/relude/pull/191):
   Implement `asumMap` and `foldMapA` by coercing `foldMap`.
   BREAKING CHANGE: Reorder type parameters to `asumMap`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog is available [on GitHub][2].
 
 ## Unreleased: 0.6.0.0
 
+* [#194](https://github.com/kowainik/relude/pull/194):
+  Use `mapToFst` instead of `zip` to improve list fusion.
 * Use `$>` instead of `*>` and `pure` where possible.
 * [#167](https://github.com/kowainik/relude/issues/167):
   Rename functions `prec`/`prev`, `dupe`/`dup`.

--- a/src/Relude/Extra/Enum.hs
+++ b/src/Relude/Extra/Enum.hs
@@ -59,10 +59,7 @@ inverseMap :: forall a k . (Bounded a, Enum a, Ord k)
 inverseMap f = \k -> M.lookup k dict
   where
     dict :: M.Map k a
-    dict = M.fromList $ map (mapToFst f) univ
-
-    univ :: [a]
-    univ = universe
+    dict = M.fromList $ map (mapToFst f) (universe @a)
 {-# INLINE inverseMap #-}
 
 {- | Like 'succ', but doesn't fail on 'maxBound'. Instead it returns 'minBound'.

--- a/src/Relude/Extra/Enum.hs
+++ b/src/Relude/Extra/Enum.hs
@@ -18,6 +18,7 @@ module Relude.Extra.Enum
        ) where
 
 import Relude
+import Relude.Extra.Tuple (mapToFst)
 
 import qualified Data.Map.Strict as M
 
@@ -58,7 +59,7 @@ inverseMap :: forall a k . (Bounded a, Enum a, Ord k)
 inverseMap f = \k -> M.lookup k dict
   where
     dict :: M.Map k a
-    dict = M.fromList $ zip (map f univ) univ
+    dict = M.fromList $ map (mapToFst f) univ
 
     univ :: [a]
     univ = universe


### PR DESCRIPTION
<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
