### PR TITLE
Reexport foldMap' from new enough versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The changelog is available [on GitHub][2].
 
 ## Unreleased: 0.6.0.0
 
+* [#192](https://github.com/kowainik/relude/issues/192):
+  Reexport `foldMap'` from `Data.Foldable`.
 * [#187](https://github.com/kowainik/relude/issues/187):
   Remove `tasty` and `tasty-hedgehog` dependencies and their redundant imports.
 * [#195](https://github.com/kowainik/relude/pull/195):

--- a/src/Relude/Foldable/Reexport.hs
+++ b/src/Relude/Foldable/Reexport.hs
@@ -20,6 +20,9 @@ module Relude.Foldable.Reexport
 import Data.Foldable (Foldable (fold, foldMap, foldl', foldr, length, null, toList), all, and, any,
                       asum, concat, concatMap, find, foldlM, forM_, for_, mapM_, or, sequenceA_,
                       sequence_, traverse_)
+#if MIN_VERSION_base(4,13,0)
+import Data.Foldable (foldMap')
+#endif
 import Data.Traversable (Traversable (..), forM, mapAccumL, mapAccumR)
 #if MIN_VERSION_base(4,10,0)
 import Data.Bifoldable (Bifoldable (..), biList, biall, biand, biany, biasum, bielem, bifind,


### PR DESCRIPTION
Resolves #192

Although there are a couple HLint rules for `foldMap`, I'm not sure if they should be copied for `foldMap'`. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [x] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [x] I've added the `[ci skip]` text to the docs-only related commit's name.
