### PR TITLE
Add property tests for the Validation type

### DIFF
--- a/relude.cabal
+++ b/relude.cabal
@@ -183,7 +183,7 @@ test-suite relude-test
   main-is:             Spec.hs
 
   other-modules:       Test.Relude.Property
-                     , Test.Relude.Extra.Validation.Property
+                       Test.Relude.Extra.Validation.Property
   build-depends:       relude
                      , bytestring
                      , text

--- a/relude.cabal
+++ b/relude.cabal
@@ -183,7 +183,7 @@ test-suite relude-test
   main-is:             Spec.hs
 
   other-modules:       Test.Relude.Property
-
+                     , Test.Relude.Extra.Validation.Property
   build-depends:       relude
                      , bytestring
                      , text

--- a/test/Test/Relude/Extra/Validation/Property.hs
+++ b/test/Test/Relude/Extra/Validation/Property.hs
@@ -46,7 +46,19 @@ asValidation gen = Gen.choice
     ]
 
 ----------------------------------------------------------------------------
--- Semogroup
+-- Property helpers
+----------------------------------------------------------------------------
+
+checkAssotiativityFor
+    :: (Show a, Eq a) => Gen a -> (a -> a -> a) -> Property
+checkAssotiativityFor gen op = property $ do
+    a <- forAll gen
+    b <- forAll gen
+    c <- forAll gen
+    a `op` (b `op` c) === (a `op` b) `op` c
+
+----------------------------------------------------------------------------
+-- Semogroup instance properties
 ----------------------------------------------------------------------------
 
 validationSemigroupProps :: Group
@@ -56,14 +68,11 @@ validationSemigroupProps =
         ]
 
 prop_semigroupAssociativity :: Property
-prop_semigroupAssociativity = property $ do
-    a <- forAll $ asValidation genSmallText
-    b <- forAll $ asValidation genSmallText
-    c <- forAll $ asValidation genSmallText
-    a <> (b <> c) === (a <> b) <> c
+prop_semigroupAssociativity =
+    checkAssotiativityFor (asValidation genSmallText) (<>)
 
 ----------------------------------------------------------------------------
--- Monoid
+-- Monoid instance properties
 ----------------------------------------------------------------------------
 
 validationMonoidProps :: Group
@@ -84,7 +93,7 @@ prop_monoidLeftIdentity = property $ do
     mempty <> x === x
 
 ----------------------------------------------------------------------------
--- Alternative
+-- Applicative instance properties
 ----------------------------------------------------------------------------
 
 validationApplicativeProps :: Group
@@ -135,7 +144,7 @@ prop_applicativeApplyLeft = property $ do
     (vy <* vx) === liftA2 const vy vx
 
 ----------------------------------------------------------------------------
--- Alternative
+-- Alternative instance properties
 ----------------------------------------------------------------------------
 
 validationAlternativeProps :: Group
@@ -147,11 +156,8 @@ validationAlternativeProps =
         ]
 
 prop_alternativeAssociativity :: Property
-prop_alternativeAssociativity = property $ do
-    a <- forAll $ asValidation genSmallText
-    b <- forAll $ asValidation genSmallText
-    c <- forAll $ asValidation genSmallText
-    (a <|> (b <|> c)) === ((a <|> b) <|> c)
+prop_alternativeAssociativity =
+    checkAssotiativityFor (asValidation genSmallText) (<|>)
 
 prop_alternativeRightIdentity :: Property
 prop_alternativeRightIdentity = property $ do

--- a/test/Test/Relude/Extra/Validation/Property.hs
+++ b/test/Test/Relude/Extra/Validation/Property.hs
@@ -1,0 +1,164 @@
+{-
+Copyright:  (c) 2016 Stephen Diehl
+            (c) 2016-2018 Serokell
+            (c) 2018-2019 Kowainik
+SPDX-License-Identifier: MIT
+Maintainer: Kowainik <xrom.xkov@gmail.com>
+-}
+
+module Test.Relude.Extra.Validation.Property
+       ( validationTestList
+       ) where
+
+import Relude
+import Relude.Extra.Validation
+
+import Hedgehog (Gen, Group (..), Property, forAll, forAllWith, property, (===))
+
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+validationTestList :: [Group]
+validationTestList =
+    [ validationSemigroupProps
+    , validationMonoidProps
+    , validationApplicativeProps
+    , validationAlternativeProps
+    ]
+
+----------------------------------------------------------------------------
+-- Generators
+----------------------------------------------------------------------------
+
+genFunction :: Gen (Int -> Int)
+genFunction = Gen.element [(+), (*), const] <*> genSmallInt
+
+genSmallInt :: Gen Int
+genSmallInt = Gen.int (Range.linear (-10) 10)
+
+genSmallText :: Gen Text
+genSmallText = Gen.text (Range.linear 3 10) Gen.unicode
+
+asValidation :: Gen a -> Gen (Validation [Text] a)
+asValidation gen = Gen.choice
+    [ Success <$> gen
+    , Failure <$> Gen.list (Range.linear 1 5) genSmallText
+    ]
+
+----------------------------------------------------------------------------
+-- Semogroup
+----------------------------------------------------------------------------
+
+validationSemigroupProps :: Group
+validationSemigroupProps =
+    Group "Semigroup instance for Validation property tests"
+        [ ("associativity:", prop_semigroupAssociativity)
+        ]
+
+prop_semigroupAssociativity :: Property
+prop_semigroupAssociativity = property $ do
+    a <- forAll $ asValidation genSmallText
+    b <- forAll $ asValidation genSmallText
+    c <- forAll $ asValidation genSmallText
+    a <> (b <> c) === (a <> b) <> c
+
+----------------------------------------------------------------------------
+-- Monoid
+----------------------------------------------------------------------------
+
+validationMonoidProps :: Group
+validationMonoidProps =
+    Group "Monoid instance for Validation property tests"
+        [ ("right identity:", prop_monoidRightIdentity)
+        , ("left identity:", prop_monoidLeftIdentity)
+        ]
+
+prop_monoidRightIdentity :: Property
+prop_monoidRightIdentity = property $ do
+    x <- forAll $ asValidation genSmallText
+    x <> mempty === x
+
+prop_monoidLeftIdentity :: Property
+prop_monoidLeftIdentity = property $ do
+    x <- forAll $ asValidation genSmallText
+    mempty <> x === x
+
+----------------------------------------------------------------------------
+-- Alternative
+----------------------------------------------------------------------------
+
+validationApplicativeProps :: Group
+validationApplicativeProps =
+    Group "Applicative instance for Validation property tests"
+        [ ("identity:", prop_applicativeIdentity)
+        , ("composition:", prop_applicativeComposition)
+        , ("homomorphism:", prop_applicativeHomomorphism)
+        , ("interchange:", prop_applicativeInterchange)
+        , ("u *> v == (id <$ u) <*> v", prop_applicativeApplyRight)
+        , ("u <* v == liftA2 const u v", prop_applicativeApplyLeft)
+        ]
+
+prop_applicativeIdentity :: Property
+prop_applicativeIdentity = property $ do
+    vx <- forAll $ asValidation genSmallText
+    (pure id <*> vx) === vx
+
+prop_applicativeComposition :: Property
+prop_applicativeComposition = property $ do
+    vf <- forAllWith (const "f") $ asValidation genFunction
+    vg <- forAllWith (const "g") $ asValidation genFunction
+    vx <- forAll $ asValidation genSmallInt
+    (pure (.) <*> vf <*> vg <*> vx) === (vf <*> (vg <*> vx))
+
+prop_applicativeHomomorphism :: Property
+prop_applicativeHomomorphism = property $ do
+    f <- forAllWith (const "f") genFunction
+    x <- forAll genSmallInt
+    (pure f <*> (pure x :: Validation [Text] Int)) === pure (f x)
+
+prop_applicativeInterchange :: Property
+prop_applicativeInterchange = property $ do
+    vf <- forAllWith (const "f") $ asValidation genFunction
+    x <- forAll genSmallInt
+    (vf <*> pure x) === (pure ($ x) <*> vf)
+
+prop_applicativeApplyRight :: Property
+prop_applicativeApplyRight = property $ do
+    vy <- forAll $ asValidation genSmallInt
+    vx <- forAll $ asValidation genSmallInt
+    (vy *> vx) === ((id <$ vy) <*> vx)
+
+prop_applicativeApplyLeft :: Property
+prop_applicativeApplyLeft = property $ do
+    vy <- forAll $ asValidation genSmallInt
+    vx <- forAll $ asValidation genSmallInt
+    (vy <* vx) === liftA2 const vy vx
+
+----------------------------------------------------------------------------
+-- Alternative
+----------------------------------------------------------------------------
+
+validationAlternativeProps :: Group
+validationAlternativeProps =
+    Group "Alternative instance for Validation property tests"
+        [ ("associativity:", prop_alternativeAssociativity)
+        , ("right identity:", prop_alternativeRightIdentity)
+        , ("left identity:", prop_alternativeLeftIdentity)
+        ]
+
+prop_alternativeAssociativity :: Property
+prop_alternativeAssociativity = property $ do
+    a <- forAll $ asValidation genSmallText
+    b <- forAll $ asValidation genSmallText
+    c <- forAll $ asValidation genSmallText
+    (a <|> (b <|> c)) === ((a <|> b) <|> c)
+
+prop_alternativeRightIdentity :: Property
+prop_alternativeRightIdentity = property $ do
+    x <- forAll $ asValidation genSmallText
+    (x <|> empty) === x
+
+prop_alternativeLeftIdentity :: Property
+prop_alternativeLeftIdentity = property $ do
+    x <- forAll $ asValidation genSmallText
+    (empty <|> x) === x

--- a/test/Test/Relude/Extra/Validation/Property.hs
+++ b/test/Test/Relude/Extra/Validation/Property.hs
@@ -1,13 +1,11 @@
 {-
-Copyright:  (c) 2016 Stephen Diehl
-            (c) 2016-2018 Serokell
-            (c) 2018-2019 Kowainik
+Copyright:  (c) 2018-2019 Kowainik
 SPDX-License-Identifier: MIT
 Maintainer: Kowainik <xrom.xkov@gmail.com>
 -}
 
 module Test.Relude.Extra.Validation.Property
-       ( validationTestList
+       ( validationLaws
        ) where
 
 import Relude
@@ -18,8 +16,8 @@ import Hedgehog (Gen, Group (..), Property, forAll, forAllWith, property, (===))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-validationTestList :: [Group]
-validationTestList =
+validationLaws :: [Group]
+validationLaws =
     [ validationSemigroupProps
     , validationMonoidProps
     , validationApplicativeProps
@@ -58,7 +56,7 @@ checkAssotiativityFor gen op = property $ do
     a `op` (b `op` c) === (a `op` b) `op` c
 
 ----------------------------------------------------------------------------
--- Semogroup instance properties
+-- Semigroup instance properties
 ----------------------------------------------------------------------------
 
 validationSemigroupProps :: Group
@@ -123,7 +121,7 @@ prop_applicativeHomomorphism :: Property
 prop_applicativeHomomorphism = property $ do
     f <- forAllWith (const "f") genFunction
     x <- forAll genSmallInt
-    (pure f <*> (pure x :: Validation [Text] Int)) === pure (f x)
+    (pure f <*> pure x) === pure @(Validation [Text]) (f x)
 
 prop_applicativeInterchange :: Property
 prop_applicativeInterchange = property $ do

--- a/test/Test/Relude/Property.hs
+++ b/test/Test/Relude/Property.hs
@@ -11,6 +11,7 @@ module Test.Relude.Property
        ) where
 
 import Relude
+import Test.Relude.Extra.Validation.Property (validationTestList)
 
 import Data.List (nub)
 import Hedgehog (Gen, Property, Group (..), assert, forAll, property, (===))
@@ -19,7 +20,11 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 hedgehogTestList :: [Group]
-hedgehogTestList = [utfProps, listProps, logicProps]
+hedgehogTestList =
+    [ utfProps
+    , listProps
+    , logicProps
+    ] <> validationTestList
 
 ----------------------------------------------------------------------------
 -- utf8 conversion

--- a/test/Test/Relude/Property.hs
+++ b/test/Test/Relude/Property.hs
@@ -11,7 +11,7 @@ module Test.Relude.Property
        ) where
 
 import Relude
-import Test.Relude.Extra.Validation.Property (validationTestList)
+import Test.Relude.Extra.Validation.Property (validationLaws)
 
 import Data.List (nub)
 import Hedgehog (Gen, Property, Group (..), assert, forAll, property, (===))
@@ -24,7 +24,7 @@ hedgehogTestList =
     [ utfProps
     , listProps
     , logicProps
-    ] <> validationTestList
+    ] <> validationLaws
 
 ----------------------------------------------------------------------------
 -- utf8 conversion


### PR DESCRIPTION
Resolves #176 

I added property tests for basic laws of `Semigroup`/`Monoid`/`Applicative`/`Alternative`.

A copule of tests checks that `<*` and `*>` work just like default implementations in `Applicative` class.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.