### PR TITLE
easier way to mixin extra modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,15 +166,15 @@ library
 ```
 
 This way, you can't access any other module of relude. If you want to use e.g.
-`Relude.Extra` (which reexports all `Relude.Extra.*` modules), you can add it
-like this:
+`Relude.Extra` (which reexports all `Relude.Extra.*` modules), you need to list
+it (and potentially other modules) under mixins field as well, like this:
 
 ```cabal
   mixins:              base hiding (Prelude)
                      , relude (Relude as Prelude, Relude.Extra)
 ```
 
-If you want to be able to import every module of relude, you need to mixin `relude`
+If you want to be able to import every module of relude, you need to add `relude`
 a second time, like this:
 
 ```cabal
@@ -182,6 +182,9 @@ a second time, like this:
                      , relude (Relude as Prelude)
                      , relude
 ```
+
+For more details on this `mixin` feature, see the
+[Cabal user guide](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-mixins).
 
 ### NoImplicitPrelude [↑](#structure-of-this-tutorial)
 

--- a/README.md
+++ b/README.md
@@ -166,11 +166,12 @@ library
 ```
 
 If you want to be able to import `Extra.*` modules when using `mixins` approach,
-you need to list those modules under `mixins` field as well, like this:
+you need to add `relude` a second time, like this:
 
 ```cabal
   mixins:              base hiding (Prelude)
-                     , relude (Relude as Prelude, Relude.Extra.Enum)
+                     , relude (Relude as Prelude)
+                     , relude
 ```
 
 ### NoImplicitPrelude [↑](#structure-of-this-tutorial)

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ library
 ```
 
 This way, you can't access any other module of relude. If you want to use e.g.
-`Relude.Extra` (which reexports all `Relude.Extra.*` modules), you need to list
-it (and potentially other modules) under mixins field as well, like this:
+`Relude.Extra.Enum`, you need to list it (and potentially other modules) under
+the `mixins` field as well, like this:
 
 ```cabal
   mixins:              base hiding (Prelude)
-                     , relude (Relude as Prelude, Relude.Extra)
+                     , relude (Relude as Prelude, Relude.Extra.Enum)
 ```
 
 If you want to be able to import every module of relude, you need to add `relude`

--- a/README.md
+++ b/README.md
@@ -183,9 +183,6 @@ a second time, like this:
                      , relude
 ```
 
-For more details on this `mixin` feature, see the
-[Cabal user guide](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-mixins).
-
 ### NoImplicitPrelude [↑](#structure-of-this-tutorial)
 
 Disable the built-in prelude at the top of your file:

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ library
   default-language:    Haskell2010
 ```
 
-This way, you can't access any other module of relude. If you want to use e.g.
-`Relude.Extra.Enum`, you need to list it (and potentially other modules) under
+If you want to use e.g. `Relude.Extra.Enum`, you need to list it
+(and potentially other modules, like `Relude.Unsafe`) under
 the `mixins` field as well, like this:
 
 ```cabal

--- a/README.md
+++ b/README.md
@@ -165,8 +165,17 @@ library
   default-language:    Haskell2010
 ```
 
-If you want to be able to import `Extra.*` modules when using `mixins` approach,
-you need to add `relude` a second time, like this:
+This way, you can't access any other module of relude. If you want to use e.g.
+`Relude.Extra` (which reexports all `Relude.Extra.*` modules), you can add it
+like this:
+
+```cabal
+  mixins:              base hiding (Prelude)
+                     , relude (Relude as Prelude, Relude.Extra)
+```
+
+If you want to be able to import every module of relude, you need to mixin `relude`
+a second time, like this:
 
 ```cabal
   mixins:              base hiding (Prelude)


### PR DESCRIPTION
Using repeated mixins, one does not have to manually add every used `Extra` module ([docs](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-mixins)).

Maybe this should also be added to the `Relude` module docs?