### PR TITLE
3 minor typo fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Main differences from `Prelude` can be grouped into the following categories:
   + `read`
   + `lookup` for lists
   + `log`
-* Completely new functions are brougth into scope
+* Completely new functions are brought into scope
   + See [What's new?](#whats-new-) section for a detailed overview.
 * New reexports
   + See [Reexports](#reexports-) section for a detailed overview.
@@ -395,7 +395,7 @@ Finally, we can move to part describing the new cool features we bring with `rel
   with clear semantic.
 * `using(Reader|State)[T]` functions as aliases for `flip run(Reader|State)[T]`.
 * [`One` type class](src/Relude/Container/One.hs)
-  for creating singleton containers. Even monomorhpic ones like `Text`.
+  for creating singleton containers. Even monomorphic ones like `Text`.
 * `evaluateWHNF` and `evaluateNF` functions as clearer and lifted aliases for
   `evaluate` and `evaluate . force`.
 * `MonadFail` instance for `Either`.

--- a/src/Relude/List/NonEmpty.hs
+++ b/src/Relude/List/NonEmpty.hs
@@ -26,7 +26,7 @@ import Relude.Monad (Maybe (..), Monad (..))
 -- $setup
 -- >>> import Relude
 
-{- | For safe work with lists using functinons for 'NonEmpty'.
+{- | For safe work with lists using functions for 'NonEmpty'.
 
 >>> viaNonEmpty head [1]
 Just 1


### PR DESCRIPTION
Resolves #{none}
This is just a fix for a typo in the README file, and one typo in a comment in source code. I don't think I need to run hlint or update the CHANGELOG.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
