### PR TITLE
Correct spelling in comments.

### DIFF
--- a/src/Relude.hs
+++ b/src/Relude.hs
@@ -207,7 +207,7 @@ functions for this type ('head', 'tail', 'last', 'init').
 
 {- $monad
 __"Relude.Monad"__ contains functions and data types from "Data.Maybe" and
-"Data.Either" modules, monad transormers and other various combinators.
+"Data.Either" modules, monad transformers and other various combinators.
 -}
 
 {- $monoid

--- a/src/Relude/Debug.hs
+++ b/src/Relude/Debug.hs
@@ -23,7 +23,7 @@ Functions for debugging. If you left these functions in your code then a warning
 is generated to remind you about left usages. Also some functions (and data
 types) are convenient for prototyping.
 
-Use these functions only for debugging purposes. They break referential trasparency,
+Use these functions only for debugging purposes. They break referential transparency,
 they are only useful when you want to observe intermediate values of your pure functions.
 -}
 

--- a/src/Relude/Exception.hs
+++ b/src/Relude/Exception.hs
@@ -52,7 +52,7 @@ impureThrow = E.throw . E.toException
 bug :: (HasCallStack, Exception e) => e -> a
 bug e = impureThrow (Bug (E.toException e) callStack)
 
-{- | Pattern synonym to easy pattern matching on exceptions. So intead of
+{- | Pattern synonym to easy pattern matching on exceptions. So instead of
 writing something like this:
 
 @

--- a/src/Relude/Extra/CallStack.hs
+++ b/src/Relude/Extra/CallStack.hs
@@ -31,7 +31,7 @@ ownName = case getCallStack callStack of
 
 {- | This function returns the name of its caller of the caller function, but it
 requires that the caller function and caller of the caller function have
-'HasCallStack' constraint. Otherwise, it returns @"<unkown>"@. It's useful for
+'HasCallStack' constraint. Otherwise, it returns @"<unknown>"@. It's useful for
 logging:
 
 >>> log :: HasCallStack => String -> IO (); log s = putStrLn $ callerName ++ ":" ++ s

--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -54,7 +54,7 @@ class Foldable f => Foldable1 f where
     fold1 :: Semigroup m => f m -> m
     fold1 = foldMap1 id
 
-    {- | Convert a non-empty data structre to a NonEmpty list.
+    {- | Convert a non-empty data structure to a NonEmpty list.
 
     >>> toNonEmpty (Identity 2)
     2 :| []
@@ -86,7 +86,7 @@ class Foldable f => Foldable1 f where
     maximum1 :: Ord a => f a -> a
     maximum1 = SG.getMax #. foldMap1 SG.Max
 
-    {- | The smallest elemenet of a non-empty data structure.
+    {- | The smallest element of a non-empty data structure.
 
     >>> minimum1 (32 :| [64, 8, 128, 16])
     8

--- a/src/Relude/Extra/Lens.hs
+++ b/src/Relude/Extra/Lens.hs
@@ -70,13 +70,13 @@ indexL   :: 'Lens'' User 'Text'
 /Note:/ here we are using composition of the lenses for @userAddress@ field. If we have
 
 @
-adressCityL :: 'Lens'' Address 'Text'
+addressCityL :: 'Lens'' Address 'Text'
 @
 
 then
 
 @
-cityL = addressL . adressCityL
+cityL = addressL . addressCityL
 @
 
 Let's say we have some sample user

--- a/src/Relude/Extra/Map.hs
+++ b/src/Relude/Extra/Map.hs
@@ -5,7 +5,7 @@ Copyright:  (c) 2018-2019 Kowainik
 SPDX-License-Identifier: MIT
 Maintainer: Kowainik <xrom.xkov@gmail.com>
 
-Contains implementation of polymorhic type classes for data types 'Set' and
+Contains implementation of polymorphic type classes for data types 'Set' and
 'Map'.
 -}
 

--- a/src/Relude/Extra/Newtype.hs
+++ b/src/Relude/Extra/Newtype.hs
@@ -38,7 +38,7 @@ un :: forall a n . Coercible a n => n -> a
 un = coerce
 {-# INLINE un #-}
 
-{- | Wraps value to @newtype@. Behaves exactly as 'un' but has more meaningnful
+{- | Wraps value to @newtype@. Behaves exactly as 'un' but has more meaningful
 name in case you need to convert some value to @newtype@.
 
 >>> newtype Flag = Flag Bool deriving (Show, Eq)
@@ -90,7 +90,7 @@ underF2 = coerce
 #endif
 
 {- | Coercible composition. This function allows to write more efficient
-implementations of functions compoitions over @newtypes@.
+implementations of function compositions over @newtypes@.
 -}
 (#.) :: Coercible b c => (b -> c) -> (a -> b) -> (a -> c)
 (#.) _f = coerce

--- a/src/Relude/Extra/Validation.hs
+++ b/src/Relude/Extra/Validation.hs
@@ -16,7 +16,7 @@ Maintainer: Kowainik <xrom.xkov@gmail.com>
 
 'Validation' is a monoidal sibling to 'Either' but 'Validation' doesn't have a
 'Monad' instance. 'Validation' allows to accumulate all errors instead of
-short-circuting on the first error so you can display all possible errors at
+short-circuiting on the first error so you can display all possible errors at
 once. Common use-cases include:
 
 1. Validating each input of a form with multiple inputs.
@@ -164,7 +164,7 @@ instance (Semigroup e, Semigroup a, Monoid a) => Monoid (Validation e a) where
     mappend = (<>)
     {-# INLINE mappend #-}
 
-{- | This instance if the most important instance for the 'Validation' data
+{- | This instance is the most important instance for the 'Validation' data
 type. It's responsible for the many implementations. And it allows to accumulate
 errors while performing validation or combining the results in the applicative
 style.

--- a/src/Relude/Monad/Either.hs
+++ b/src/Relude/Monad/Either.hs
@@ -10,7 +10,7 @@ Copyright:  (c) 2016 Stephen Diehl
 SPDX-License-Identifier: MIT
 Maintainer: Kowainik <xrom.xkov@gmail.com>
 
-Utilites to work with @Either@ data type.
+Utilities to work with @Either@ data type.
 -}
 
 module Relude.Monad.Either

--- a/src/Relude/Nub.hs
+++ b/src/Relude/Nub.hs
@@ -17,7 +17,7 @@ Functions to remove duplicates from a list.
  * Lists which consist of many same elements
 
 
- Here are some recomendations for usage of particular functions based on benchmarking resutls.
+ Here are some recommendations for usage of particular functions based on benchmarking results.
 
  * 'hashNub' is faster than 'ordNub' when there're not so many different values in the list.
 

--- a/src/Relude/Numeric.hs
+++ b/src/Relude/Numeric.hs
@@ -54,7 +54,7 @@ integerToBounded n
     | otherwise                   = Just (fromIntegral n)
 {-# INLINE integerToBounded #-}
 
-{- | Tranforms an integer number to a natural.
+{- | Transforms an integer number to a natural.
 Only non-negative integers are considered natural, everything else will return `Nothing`.
 
 >>> integerToNatural (-1)

--- a/src/Relude/String.hs
+++ b/src/Relude/String.hs
@@ -5,7 +5,7 @@ Copyright:  (c) 2016 Stephen Diehl
 SPDX-License-Identifier: MIT
 Maintainer: Kowainik <xrom.xkov@gmail.com>
 
-Type classes for convertion between different string representations.
+Type classes for conversion between different string representations.
 -}
 
 module Relude.String

--- a/src/Relude/Unsafe.hs
+++ b/src/Relude/Unsafe.hs
@@ -41,7 +41,7 @@ get element from list using index value starting from `0`.
 >>> at 2 ["a", "b", "c"]
 "c"
 
-it is also usefull when used in a partially applied position like:
+it is also useful when used in a partially applied position like:
 
 >>> map (at 1) [["a","b","c"], ["a","b","c"], ["a","b","c"]]
 ["b","b","b"]


### PR DESCRIPTION
Resolves #{N/A}
It does not resolve any issues. Though it is related to #229.
<!-- You can add any comments here -->

The change in src/Relude/Extra/Lens.h was a change of an identifier name in a comment. Specifically: addressCityL had an extra 'd'

In src/Relude/Extra/CallStack.hs line 34, the spelling of an "<unknown>" in a comment was wrong. The spelling in the code was correct and was not changed. 

In src/Relude/Nub.hs, I corrected the spelling to "recommendations", and "results". Both were on the same line. 

I had to change "functions" from plural to singular in src/Relude/Extra/Newtype.hs (line 93)
I changed "if" to "is" to make a sentence grammatical in src/Relude/Extra/Validation.hs (line 167)

The rest of the changes are much simpler, and straightforward. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [?] I've updated the documentation accordingly.
- [x] I've added the `[ci skip]` text to the docs-only related commit's name.

I'm unsure what is meant by I've updated the documentation accordingly. My change is only changes in documentation. I assume, that the build system will generate the haddock files from the comments, and I don't have to do it manually. 
