### PR TITLE
[#234] scan{l,r}1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The changelog is available [on GitHub][2].
     + `dupe`: use `dup` instead
     + `mapBoth`: use `bimapBoth` instead
 
+* [#234](https://github.com/kowainik/relude/issues/234):
+  Reexport `scanl1`, `scanr1`, `scanl'` from `Data.List`.
+
 ## 0.6.0.0 — Oct 30, 2019
 
 * [#171](https://github.com/kowainik/relude/issues/171):

--- a/hlint/hlint.dhall
+++ b/hlint/hlint.dhall
@@ -699,6 +699,7 @@ in [ Rule.Arguments { arguments =
    , warnReexport "intersperse"      "Data.List"
    , warnReexport "isPrefixOf"       "Data.List"
    , warnReexport "permutations"     "Data.List"
+   , warnReexport "scanl'"           "Data.List"
    , warnReexport "sort"             "Data.List"
    , warnReexport "sortBy"           "Data.List"
    , warnReexport "sortOn"           "Data.List"

--- a/src/Relude/List/Reexport.hs
+++ b/src/Relude/List/Reexport.hs
@@ -41,9 +41,9 @@ module Relude.List.Reexport
 
 import Data.List (break, drop, dropWhile, filter, genericDrop, genericLength, genericReplicate,
                   genericSplitAt, genericTake, group, inits, intercalate, intersperse, isPrefixOf,
-                  iterate, map, permutations, repeat, replicate, reverse, scanl, scanr, sort,
-                  sortBy, sortOn, splitAt, subsequences, tails, take, takeWhile, transpose, uncons,
-                  unfoldr, unzip, unzip3, zip, zip3, zipWith, (++))
+                  iterate, map, permutations, repeat, replicate, reverse, scanl, scanl', scanl1,
+                  scanr, scanr1, sort, sortBy, sortOn, splitAt, subsequences, tails, take,
+                  takeWhile, transpose, uncons, unfoldr, unzip, unzip3, zip, zip3, zipWith, (++))
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import GHC.Exts (sortWith)
 import GHC.TypeLits (ErrorMessage (..), Symbol, TypeError)


### PR DESCRIPTION
Resolves #234
:warning: I could not regenerate hlint file due to issue with `dhall-to-yaml`. Though I added the new rule, so when #264 is done, these changes should be applied as well..
