### PR TITLE
[#285] List functions Haddock Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ The changelog is available [on GitHub][2].
   + Replace `mapToSnd` with `toSnd`
   + You can now use `fmapToFst` and `fmapToSnd` instead of
     `[f]map (mapToFst f)` and `[f]map (mapToSnd f)`
+* Reexport `NonEmpty` functions from `Relude.List.NonEmpty` instead of
+  `Relude.List.Reexport`.
 
 ## 0.6.0.0 — Oct 30, 2019
 

--- a/src/Relude/List.hs
+++ b/src/Relude/List.hs
@@ -62,11 +62,12 @@ infix 9 !!?
 {-# INLINE (!!?) #-}
 
 {- $reexport
-Most of the "Data.List" and "Data.List.NonEmpty" types and function.
-List partial functions are not exported from "Data.List", but from
-"Data.List.NonEmpty" instead.
+Most of the "Data.List" types and function.
+Note, that list partial functions are not exported from "Data.List", but from
+"Relude.List.NonEmpty" instead.
 -}
 
 {- $nonempty
-Additional safe functions to work with list type in terms of 'NonEmpty'.
+Reexports from "Data.List.NonEmpty" and additional safe functions to work with
+list type in terms of 'NonEmpty'.
 -}

--- a/src/Relude/List.hs
+++ b/src/Relude/List.hs
@@ -63,8 +63,12 @@ infix 9 !!?
 
 {- $reexport
 Most of the "Data.List" types and function.
-Note, that list partial functions are not exported from "Data.List", but from
-"Relude.List.NonEmpty" instead.
+
+Note, that list partial functions (e.g. 'Data.List.head') are not exported from
+"Data.List".
+Instead @relude@ provides safe functions that work with
+'Data.List.NonEmpty.NonEmpty'. You can find them in the
+"Relude.List.NonEmpty" module instead.
 -}
 
 {- $nonempty

--- a/src/Relude/List/NonEmpty.hs
+++ b/src/Relude/List/NonEmpty.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE KindSignatures       #-}
 {-# LANGUAGE Safe                 #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}

--- a/src/Relude/List/NonEmpty.hs
+++ b/src/Relude/List/NonEmpty.hs
@@ -1,4 +1,10 @@
-{-# LANGUAGE Safe #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE Safe                 #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {- |
 Copyright:  (c) 2016 Stephen Diehl
@@ -9,20 +15,75 @@ Maintainer:  Kowainik <xrom.xkov@gmail.com>
 Stability:   Stable
 Portability: Portable
 
-This module contains safe functions to work with list type in terms of 'NonEmpty'.
+This module contains reexports from "data.List.NonEmpty" and safe functions to
+work with list type in terms of 'NonEmpty'.
+
+Note, that Relude reexports 'head', 'tail', 'init', 'last' from
+"Data.List.NonEmpty" instead of the "Data.List", so these functions are safe to
+use.
+
+@relude@ also provides custom type error for better experience with transition
+from lists to 'NonEmpty' with those functions.
+
+
+Let's examine the behaviour of the @relude@ list functions comparing to the
+corresponding @base@ one on the example of the 'head' function:
+
++-----------------+-----------------------------------------+
+|                 |         'head'                          |
++=================+=========================================+
+| __@base@__      | @[a] -> a@                              |
++-----------------+-----------------------------------------+
+| __@relude@__    | @'NonEmpty' a -> a@                     |
++-----------------+-----------------------------------------+
+| Example         | @> 'Data.List.head' [1..5]@             |
+| with list       +-----------------------------------------+
+| __@base@__      | @1@                                     |
++-----------------+-----------------------------------------+
+| Example         | @> 'Data.List.head' []@                 |
+| with empty list +-----------------------------------------+
+| __@base@__      |@*** Exception: Prelude.head: empty list@|
++-----------------+-----------------------------------------+
+| Example         |@> 'head' $ 1 :| [2..5]@                 |
+| with 'NonEmpty' +-----------------------------------------+
+| __@relude@__    | @1@                                     |
++-----------------+-----------------------------------------+
+| Example         | @> 'viaNonEmpty' 'head' [1..5]@         |
+| with list       +-----------------------------------------+
+| __@relude@__    | @'Just' 1@                              |
++-----------------+-----------------------------------------+
+| Example         |@> 'viaNonEmpty' 'head' []@              |
+| with empty list +-----------------------------------------+
+| __@relude@__    | @'Nothing'@                             |
++-----------------+-----------------------------------------+
+
 -}
 
 module Relude.List.NonEmpty
-    ( viaNonEmpty
+    ( -- Reexports from "DataList.NonEmpty"
+      NonEmpty (..)
+    , nonEmpty
+    , head
+    , init
+    , last
+    , tail
+
+      -- * Combinators
+    , viaNonEmpty
     , whenNotNull
     , whenNotNullM
     ) where
 
+import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
+import GHC.TypeLits (ErrorMessage (..), Symbol, TypeError)
+
 import Relude.Applicative (Applicative, pass)
+import Relude.Base (Constraint, Type)
 import Relude.Function ((.))
 import Relude.Functor (fmap)
-import Relude.List.Reexport (NonEmpty (..), nonEmpty)
 import Relude.Monad (Maybe (..), Monad (..))
+
+import qualified Data.List.NonEmpty as NE (head, init, last, tail)
 
 
 -- $setup
@@ -54,3 +115,187 @@ whenNotNull (x:xs) f = f (x :| xs)
 whenNotNullM :: Monad m => m [a] -> (NonEmpty a -> m ()) -> m ()
 whenNotNullM ml f = ml >>= \l -> whenNotNull l f
 {-# INLINE whenNotNullM #-}
+
+
+-- | For tracking usage of ordinary list with @head@-like functions.
+type IsNonEmpty
+    (f :: Type -> Type)  -- Container, e.g. NonEmpty or []
+    (a :: Type)          -- Type of the element
+    (res :: Type)        -- Type of the result of the work of the function
+    (fun :: Symbol)      -- Function name
+    = (f ~ NonEmpty, CheckNonEmpty f a res fun)
+
+type family CheckNonEmpty
+    (f :: Type -> Type)
+    (a :: Type)
+    (res :: Type)
+    (fun :: Symbol)
+    :: Constraint
+  where
+    CheckNonEmpty NonEmpty _ _ _ = ()
+    CheckNonEmpty [] a res fun = TypeError
+        ( 'Text "'" ':<>: 'Text fun ':<>: 'Text "' works with 'NonEmpty', not ordinary lists."
+        ':$$: 'Text "Possible fix:"
+        ':$$: 'Text "    Replace: [" ':<>: 'ShowType a ':<>: 'Text "]"
+        ':$$: 'Text "    With:    NonEmpty " ':<>: 'ShowType a
+        ':$$: 'Text ""
+        ':$$: 'Text "However, you can use '" ':<>: 'Text fun ':<>: 'Text "' with the ordinary lists."
+        ':$$: 'Text "Apply 'viaNonEmpty' function from relude:"
+        ':$$: 'Text "    viaNonEmpty " ':<>: 'Text fun ':<>: 'Text " (yourList)"
+        ':$$: 'Text "Note, that this will return 'Maybe " ':<>: 'ShowType res ':<>: 'Text "'"
+        ':$$: 'Text "therefore it is a safe function unlike '" ':<>: 'Text fun ':<>: 'Text "' from the standard Prelude"
+        )
+    CheckNonEmpty t a _ fun = TypeError
+        ( 'Text "'"
+        ':<>: 'Text fun
+        ':<>: 'Text "' works with 'NonEmpty "
+        ':<>: 'ShowType a
+        ':<>: 'Text "' lists"
+        ':$$: 'Text "But given: "
+        ':<>: 'ShowType t
+        ':<>: 'Text " "
+        ':<>: 'ShowType a
+        )
+
+
+{- | @O(1)@. Extracts the first element of a 'NonEmpty' list.
+
+Actual type of this function is the following:
+
+@
+head :: 'NonEmpty' a -> a
+@
+
+but it was given a more complex type to provide friendlier compile time errors.
+
+>>> head ('a' :| "bcde")
+'a'
+>>> head [0..5 :: Int]
+...
+... 'head' works with 'NonEmpty', not ordinary lists.
+      Possible fix:
+          Replace: [Int]
+          With:    NonEmpty Int
+...
+      However, you can use 'head' with the ordinary lists.
+      Apply 'viaNonEmpty' function from relude:
+          viaNonEmpty head (yourList)
+      Note, that this will return 'Maybe Int'
+      therefore it is a safe function unlike 'head' from the standard Prelude
+...
+>>> head (Just 'a')
+...
+... 'head' works with 'NonEmpty Char' lists
+      But given: Maybe Char
+...
+-}
+head :: IsNonEmpty f a a "head" => f a -> a
+head = NE.head
+{-# INLINE head #-}
+
+{- | @O(n)@. Return all the elements of a 'NonEmpty' list except the last one
+element.
+
+Actual type of this function is the following:
+
+@
+init :: 'NonEmpty' a -> [a]
+@
+
+but it was given a more complex type to provide friendlier compile time errors.
+
+>>> init ('a' :| "bcde")
+"abcd"
+>>> init [0..5 :: Int]
+...
+... 'init' works with 'NonEmpty', not ordinary lists.
+      Possible fix:
+          Replace: [Int]
+          With:    NonEmpty Int
+...
+      However, you can use 'init' with the ordinary lists.
+      Apply 'viaNonEmpty' function from relude:
+          viaNonEmpty init (yourList)
+      Note, that this will return 'Maybe [Int]'
+      therefore it is a safe function unlike 'init' from the standard Prelude
+...
+>>> init (Just 'a')
+...
+... 'init' works with 'NonEmpty Char' lists
+      But given: Maybe Char
+...
+-}
+init :: IsNonEmpty f a [a] "init" => f a -> [a]
+init = NE.init
+{-# INLINE init #-}
+
+{- | @O(n)@. Extracts the last element of a 'NonEmpty' list.
+
+Actual type of this function is the following:
+
+@
+last :: 'NonEmpty' a -> a
+@
+
+but it was given a more complex type to provide friendlier compile time errors.
+
+>>> last ('a' :| "bcde")
+'e'
+>>> last [0..5 :: Int]
+...
+... 'last' works with 'NonEmpty', not ordinary lists.
+      Possible fix:
+          Replace: [Int]
+          With:    NonEmpty Int
+...
+      However, you can use 'last' with the ordinary lists.
+      Apply 'viaNonEmpty' function from relude:
+          viaNonEmpty last (yourList)
+      Note, that this will return 'Maybe Int'
+      therefore it is a safe function unlike 'last' from the standard Prelude
+...
+>>> last (Just 'a')
+...
+... 'last' works with 'NonEmpty Char' lists
+      But given: Maybe Char
+...
+-}
+last :: IsNonEmpty f a a "last" => f a -> a
+last = NE.last
+{-# INLINE last #-}
+
+{- | @O(1)@. Return all the elements of a 'NonEmpty' list after the head
+element.
+
+Actual type of this function is the following:
+
+@
+tail :: 'NonEmpty' a -> [a]
+@
+
+but it was given a more complex type to provide friendlier compile time errors.
+
+>>> tail ('a' :| "bcde")
+"bcde"
+>>> tail [0..5 :: Int]
+...
+... 'tail' works with 'NonEmpty', not ordinary lists.
+      Possible fix:
+          Replace: [Int]
+          With:    NonEmpty Int
+...
+      However, you can use 'tail' with the ordinary lists.
+      Apply 'viaNonEmpty' function from relude:
+          viaNonEmpty tail (yourList)
+      Note, that this will return 'Maybe [Int]'
+      therefore it is a safe function unlike 'tail' from the standard Prelude
+...
+>>> tail (Just 'a')
+...
+... 'tail' works with 'NonEmpty Char' lists
+      But given: Maybe Char
+...
+-}
+tail :: IsNonEmpty f a [a] "tail" => f a -> [a]
+tail = NE.tail
+{-# INLINE tail #-}

--- a/src/Relude/List/NonEmpty.hs
+++ b/src/Relude/List/NonEmpty.hs
@@ -21,6 +21,18 @@ Note, that "Relude" reexports 'head', 'tail', 'init', 'last' from
 "Data.List.NonEmpty" instead of the "Data.List", so these functions are safe to
 use.
 
++------------+--------------+-----------------------+
+|            |    @base@    |       @relude@        |
++============+==============+=======================+
+| __'head'__ | @[a] -> a@   | @'NonEmpty' a -> a@   |
++------------+--------------+-----------------------+
+| __'tail'__ | @[a] -> [a]@ | @'NonEmpty' a -> [a]@ |
++------------+--------------+-----------------------+
+| __'last'__ | @[a] -> a@   | @'NonEmpty' a -> a@   |
++------------+--------------+-----------------------+
+| __'init'__ | @[a] -> [a]@ | @'NonEmpty' a -> [a]@ |
++------------+--------------+-----------------------+
+
 @relude@ also provides custom type error for better experience with transition
 from lists to 'NonEmpty' with those functions.
 
@@ -63,9 +75,9 @@ module Relude.List.NonEmpty
       NonEmpty (..)
     , nonEmpty
     , head
-    , init
-    , last
     , tail
+    , last
+    , init
 
       -- * Combinators
     , viaNonEmpty

--- a/src/Relude/List/NonEmpty.hs
+++ b/src/Relude/List/NonEmpty.hs
@@ -14,10 +14,10 @@ Maintainer:  Kowainik <xrom.xkov@gmail.com>
 Stability:   Stable
 Portability: Portable
 
-This module contains reexports from "data.List.NonEmpty" and safe functions to
+This module contains reexports from "Data.List.NonEmpty" and safe functions to
 work with list type in terms of 'NonEmpty'.
 
-Note, that Relude reexports 'head', 'tail', 'init', 'last' from
+Note, that "Relude" reexports 'head', 'tail', 'init', 'last' from
 "Data.List.NonEmpty" instead of the "Data.List", so these functions are safe to
 use.
 
@@ -59,7 +59,7 @@ corresponding @base@ one on the example of the 'head' function:
 -}
 
 module Relude.List.NonEmpty
-    ( -- Reexports from "DataList.NonEmpty"
+    ( -- * Reexports from "DataList.NonEmpty"
       NonEmpty (..)
     , nonEmpty
     , head

--- a/src/Relude/List/Reexport.hs
+++ b/src/Relude/List/Reexport.hs
@@ -1,10 +1,4 @@
-{-# LANGUAGE ConstraintKinds      #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE KindSignatures       #-}
-{-# LANGUAGE Trustworthy          #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE Trustworthy #-}
 
 {- |
 Copyright:  (c) 2016 Stephen Diehl
@@ -15,14 +9,7 @@ Maintainer:  Kowainik <xrom.xkov@gmail.com>
 Stability:   Stable
 Portability: Portable
 
-Reexports most of the "Data.List" and "Data.List.NonEmpty".
-
-Note, that Relude reexports 'head', 'tail', 'init', 'last' from
-"Data.List.NonEmpty" instead of the "Data.List", so these functions are safe to
-use.
-
-@relude@ also provides custom type error for better experience with transition
-from lists to 'NonEmpty' with those functions.
+Reexports most of the "Data.List".
 -}
 
 module Relude.List.Reexport
@@ -30,13 +17,6 @@ module Relude.List.Reexport
       module Data.List
     , cycle
     , sortWith
-      -- * NonEmpty List
-    , NonEmpty (..)
-    , nonEmpty
-    , head
-    , init
-    , last
-    , tail
     ) where
 
 import Data.List (break, drop, dropWhile, filter, genericDrop, genericLength, genericReplicate,
@@ -44,13 +24,7 @@ import Data.List (break, drop, dropWhile, filter, genericDrop, genericLength, ge
                   iterate, map, permutations, repeat, replicate, reverse, scanl, scanl', scanl1,
                   scanr, scanr1, sort, sortBy, sortOn, splitAt, subsequences, tails, take,
                   takeWhile, transpose, uncons, unfoldr, unzip, unzip3, zip, zip3, zipWith, (++))
-import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import GHC.Exts (sortWith)
-import GHC.TypeLits (ErrorMessage (..), Symbol, TypeError)
-
-import Relude.Base (Constraint, Type)
-
-import qualified Data.List.NonEmpty as NE (head, init, last, tail)
 
 
 -- $setup
@@ -71,186 +45,3 @@ cycle [] = []
 cycle xs = cycledList
   where
     cycledList = xs ++ cycledList
-
--- | For tracking usage of ordinary list with @head@-like functions.
-type IsNonEmpty
-    (f :: Type -> Type)  -- Container, e.g. NonEmpty or []
-    (a :: Type)          -- Type of the element
-    (res :: Type)        -- Type of the result of the work of the function
-    (fun :: Symbol)      -- Function name
-    = (f ~ NonEmpty, CheckNonEmpty f a res fun)
-
-type family CheckNonEmpty
-    (f :: Type -> Type)
-    (a :: Type)
-    (res :: Type)
-    (fun :: Symbol)
-    :: Constraint
-  where
-    CheckNonEmpty NonEmpty _ _ _ = ()
-    CheckNonEmpty [] a res fun = TypeError
-        ( 'Text "'" ':<>: 'Text fun ':<>: 'Text "' works with 'NonEmpty', not ordinary lists."
-        ':$$: 'Text "Possible fix:"
-        ':$$: 'Text "    Replace: [" ':<>: 'ShowType a ':<>: 'Text "]"
-        ':$$: 'Text "    With:    NonEmpty " ':<>: 'ShowType a
-        ':$$: 'Text ""
-        ':$$: 'Text "However, you can use '" ':<>: 'Text fun ':<>: 'Text "' with the ordinary lists."
-        ':$$: 'Text "Apply 'viaNonEmpty' function from relude:"
-        ':$$: 'Text "    viaNonEmpty " ':<>: 'Text fun ':<>: 'Text " (yourList)"
-        ':$$: 'Text "Note, that this will return 'Maybe " ':<>: 'ShowType res ':<>: 'Text "'"
-        ':$$: 'Text "therefore it is a safe function unlike '" ':<>: 'Text fun ':<>: 'Text "' from the standard Prelude"
-        )
-    CheckNonEmpty t a _ fun = TypeError
-        ( 'Text "'"
-        ':<>: 'Text fun
-        ':<>: 'Text "' works with 'NonEmpty "
-        ':<>: 'ShowType a
-        ':<>: 'Text "' lists"
-        ':$$: 'Text "But given: "
-        ':<>: 'ShowType t
-        ':<>: 'Text " "
-        ':<>: 'ShowType a
-        )
-
-
-{- | @O(1)@. Extracts the first element of a 'NonEmpty' list.
-
-Actual type of this function is the following:
-
-@
-head :: 'NonEmpty' a -> a
-@
-
-but it was given a more complex type to provide friendlier compile time errors.
-
->>> head ('a' :| "bcde")
-'a'
->>> head [0..5 :: Int]
-...
-... 'head' works with 'NonEmpty', not ordinary lists.
-      Possible fix:
-          Replace: [Int]
-          With:    NonEmpty Int
-...
-      However, you can use 'head' with the ordinary lists.
-      Apply 'viaNonEmpty' function from relude:
-          viaNonEmpty head (yourList)
-      Note, that this will return 'Maybe Int'
-      therefore it is a safe function unlike 'head' from the standard Prelude
-...
->>> head (Just 'a')
-...
-... 'head' works with 'NonEmpty Char' lists
-      But given: Maybe Char
-...
--}
-head :: IsNonEmpty f a a "head" => f a -> a
-head = NE.head
-{-# INLINE head #-}
-
-{- | @O(n)@. Return all the elements of a 'NonEmpty' list except the last one
-element.
-
-Actual type of this function is the following:
-
-@
-init :: 'NonEmpty' a -> [a]
-@
-
-but it was given a more complex type to provide friendlier compile time errors.
-
->>> init ('a' :| "bcde")
-"abcd"
->>> init [0..5 :: Int]
-...
-... 'init' works with 'NonEmpty', not ordinary lists.
-      Possible fix:
-          Replace: [Int]
-          With:    NonEmpty Int
-...
-      However, you can use 'init' with the ordinary lists.
-      Apply 'viaNonEmpty' function from relude:
-          viaNonEmpty init (yourList)
-      Note, that this will return 'Maybe [Int]'
-      therefore it is a safe function unlike 'init' from the standard Prelude
-...
->>> init (Just 'a')
-...
-... 'init' works with 'NonEmpty Char' lists
-      But given: Maybe Char
-...
--}
-init :: IsNonEmpty f a [a] "init" => f a -> [a]
-init = NE.init
-{-# INLINE init #-}
-
-{- | @O(n)@. Extracts the last element of a 'NonEmpty' list.
-
-Actual type of this function is the following:
-
-@
-last :: 'NonEmpty' a -> a
-@
-
-but it was given a more complex type to provide friendlier compile time errors.
-
->>> last ('a' :| "bcde")
-'e'
->>> last [0..5 :: Int]
-...
-... 'last' works with 'NonEmpty', not ordinary lists.
-      Possible fix:
-          Replace: [Int]
-          With:    NonEmpty Int
-...
-      However, you can use 'last' with the ordinary lists.
-      Apply 'viaNonEmpty' function from relude:
-          viaNonEmpty last (yourList)
-      Note, that this will return 'Maybe Int'
-      therefore it is a safe function unlike 'last' from the standard Prelude
-...
->>> last (Just 'a')
-...
-... 'last' works with 'NonEmpty Char' lists
-      But given: Maybe Char
-...
--}
-last :: IsNonEmpty f a a "last" => f a -> a
-last = NE.last
-{-# INLINE last #-}
-
-{- | @O(1)@. Return all the elements of a 'NonEmpty' list after the head
-element.
-
-Actual type of this function is the following:
-
-@
-tail :: 'NonEmpty' a -> [a]
-@
-
-but it was given a more complex type to provide friendlier compile time errors.
-
->>> tail ('a' :| "bcde")
-"bcde"
->>> tail [0..5 :: Int]
-...
-... 'tail' works with 'NonEmpty', not ordinary lists.
-      Possible fix:
-          Replace: [Int]
-          With:    NonEmpty Int
-...
-      However, you can use 'tail' with the ordinary lists.
-      Apply 'viaNonEmpty' function from relude:
-          viaNonEmpty tail (yourList)
-      Note, that this will return 'Maybe [Int]'
-      therefore it is a safe function unlike 'tail' from the standard Prelude
-...
->>> tail (Just 'a')
-...
-... 'tail' works with 'NonEmpty Char' lists
-      But given: Maybe Char
-...
--}
-tail :: IsNonEmpty f a [a] "tail" => f a -> [a]
-tail = NE.tail
-{-# INLINE tail #-}


### PR DESCRIPTION
Resolves #285

Reexport `NonEmpty` functions from `Relude.List.NonEmpty` instead of `Relude.List.Reexport`.