### PR TITLE
Add traceShowIdMsg

### DIFF
--- a/src/Relude/Debug.hs
+++ b/src/Relude/Debug.hs
@@ -48,6 +48,7 @@ module Relude.Debug
     , traceId
     , traceShow
     , traceShowId
+    , traceShowIdMsg
     , traceShowM
 
       -- * Imprecise error
@@ -120,6 +121,18 @@ traceShowId :: Show a => a -> a
 traceShowId = Debug.traceShowId
 {-# WARNING traceShowId "'traceShowId' remains in code" #-}
 
+{- | Like 'traceShowId', but allows you to specify a message (for tracing
+multiple values).
+
+>>> traceShowIdMsg "value:" (1+2+3, "hello" ++ "world")
+value: (6,"helloworld")
+(6,"helloworld")
+
+-}
+traceShowIdMsg :: Show a => String -> a -> a
+traceShowIdMsg msg v = Debug.trace (msg Prelude.++ " " Prelude.++ Prelude.show v) v
+{-# WARNING traceShowIdMsg "'traceShowIdMsg' remains in code" #-}
+
 {- | Version of 'Debug.Trace.traceM' that leaves warning.
 
 >>> :{
@@ -184,13 +197,13 @@ error handling mechanism.
 >>> error "oops"
 *** Exception: oops
 CallStack (from HasCallStack):
-  error, called at src\\Relude\\Debug.hs:218:11 in ...
+  error, called at src\\Relude\\Debug.hs:231:11 in ...
   ...
 #else
 >>> error "oops"
 *** Exception: oops
 CallStack (from HasCallStack):
-  error, called at src/Relude/Debug.hs:218:11 in ...
+  error, called at src/Relude/Debug.hs:231:11 in ...
 ...
 #endif
 


### PR DESCRIPTION
This PR adds a function called `traceShowIdMsg`, which is like `traceShowId` but allows you to annotate the traced value with a message. I've found this really useful for debugging when I want to trace multiple values at once.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
