### PR TITLE
Add maximumOn1, and minimumOn1 functions for Foldable1(no default imp…

### DIFF
--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -110,20 +110,22 @@ class Foldable f => Foldable1 f where
     {- | The largest element of a non-empty data structure
          with respect to the given comparison function.
 
-    >>> maximumOn1 sin (32 :| [64, 8, 128, 16])
-    8.0
+    >>> maximumOn1 abs (0 :| [2, 1, -3, -2])
+    -3
     -}
     maximumOn1 :: Ord b => (a -> b) -> f a -> a
     maximumOn1 f = maximumOn1 f . toNonEmpty
+    {-# INLINE maximumOn1 #-}
 
     {- | The smallest element of a non-empty data structure
          with respect to the given comparison function.
 
-    >>> minimumOn1 sin (32 :| [64, 8, 128, 16])
-    16.0
+    >>> minimumOn1 abs (0 :| [2, 1, -3, -2])
+    0
     -}
     minimumOn1 :: Ord b => (a -> b) -> f a -> a
     minimumOn1 f = minimumOn1 f . toNonEmpty
+    {-# INLINE minimumOn1 #-}
 
 {- |
 

--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -108,14 +108,16 @@ class Foldable f => Foldable1 f where
     minimum1 :: Ord a => f a -> a
     minimum1 = SG.getMin #. foldMap1 SG.Min
 
-    {- | The largest element of a non-empty data structure.
+    {- | The largest element of a non-empty data structure
+         with respect to the given comparison function.
 
     >>> maximumOn1 sin (32 :| [64, 8, 128, 16])
     8.0
     -}
     maximumOn1 :: (Ord b, Foldable1 f) => (a -> b) -> f a -> a
 
-    {- | The smallest element of a non-empty data structure.
+    {- | The smallest element of a non-empty data structure
+         with respect to the given comparison function.
 
     >>> minimumOn1 sin (32 :| [64, 8, 128, 16])
     16.0
@@ -157,17 +159,17 @@ instance Foldable1 NonEmpty where
     maximumOn1 :: Ord b => (a -> b) -> NonEmpty a -> a
     maximumOn1 func = foldl1' (cmpOn func)
       where
-        cmpOn p a b = case (p a) `compare` (p b) of
+        cmpOn p a b = case p a `compare` p b of
                         GT -> a
-                        _ -> b
+                        _  -> b
     {-# INLINE maximumOn1 #-}
 
     minimumOn1 :: Ord b => (a -> b) -> NonEmpty a -> a
     minimumOn1 func = foldl1' (cmpOn func)
       where
-        cmpOn p a b = case (p a) `compare` (p b) of
+        cmpOn p a b = case p a `compare` p b of
                         LT -> a
-                        _ -> b
+                        _  -> b
     {-# INLINE minimumOn1 #-}
 
 {- |
@@ -341,7 +343,7 @@ instance IsListError => Foldable1 [] where
 
     minimum1 :: Ord a => [a] -> a
     minimum1 _ = error "Unreachable list instance of Foldable1"
-    
+
     maximumOn1 :: (Ord b, Foldable1 f) => (a -> b) -> f a -> a
     maximumOn1 _ _ = error "Unreachable list instance of Foldable1"
 

--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -46,7 +46,7 @@ import qualified Data.Semigroup as SG
 @since 0.3.0
 -}
 class Foldable f => Foldable1 f where
-    {-# MINIMAL foldMap1, maximumOn1, minimumOn1 #-}
+    {-# MINIMAL foldMap1 #-}
 
     {- | Map each element of the non-empty structure to a semigroup, and combine the results.
 
@@ -114,6 +114,7 @@ class Foldable f => Foldable1 f where
     8.0
     -}
     maximumOn1 :: Ord b => (a -> b) -> f a -> a
+    maximumOn1 f = maximumOn1 f . toNonEmpty
 
     {- | The smallest element of a non-empty data structure
          with respect to the given comparison function.
@@ -122,6 +123,7 @@ class Foldable f => Foldable1 f where
     16.0
     -}
     minimumOn1 :: Ord b => (a -> b) -> f a -> a
+    minimumOn1 f = minimumOn1 f . toNonEmpty
 
 {- |
 

--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -46,7 +46,7 @@ import qualified Data.Semigroup as SG
 @since 0.3.0
 -}
 class Foldable f => Foldable1 f where
-    {-# MINIMAL foldMap1 #-}
+    {-# MINIMAL foldMap1, maximumOn1, minimumOn1 #-}
 
     {- | Map each element of the non-empty structure to a semigroup, and combine the results.
 
@@ -155,20 +155,22 @@ instance Foldable1 NonEmpty where
     {-# INLINE maximum1 #-}
     {-# INLINE minimum1 #-}
 
-    maximumOn1 :: Ord b => (a -> b) -> NonEmpty a -> a
-    maximumOn1 func = foldl1' (cmpOn func)
+    maximumOn1 :: forall a b. Ord b => (a -> b) -> NonEmpty a -> a
+    maximumOn1 func = foldl1' $ cmpOn
       where
-        cmpOn p a b = case p a `compare` p b of
+        cmpOn :: a -> a -> a
+        cmpOn a b = case func a `compare` func b of
                         GT -> a
-                        _  -> b
+                        _ -> b
     {-# INLINE maximumOn1 #-}
 
-    minimumOn1 :: Ord b => (a -> b) -> NonEmpty a -> a
-    minimumOn1 func = foldl1' (cmpOn func)
+    minimumOn1 :: forall a b. Ord b => (a -> b) -> NonEmpty a -> a
+    minimumOn1 func = foldl1' $ cmpOn
       where
-        cmpOn p a b = case p a `compare` p b of
+        cmpOn :: a -> a -> a
+        cmpOn a b = case func a `compare` func b of
                         LT -> a
-                        _  -> b
+                        _ -> b
     {-# INLINE minimumOn1 #-}
 
 {- |

--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ConstrainedClassMethods #-}
 
 {- |
 Copyright:  (c) 2011-2015 Edward Kmett
@@ -114,7 +113,7 @@ class Foldable f => Foldable1 f where
     >>> maximumOn1 sin (32 :| [64, 8, 128, 16])
     8.0
     -}
-    maximumOn1 :: (Ord b, Foldable1 f) => (a -> b) -> f a -> a
+    maximumOn1 :: Ord b => (a -> b) -> f a -> a
 
     {- | The smallest element of a non-empty data structure
          with respect to the given comparison function.
@@ -122,7 +121,7 @@ class Foldable f => Foldable1 f where
     >>> minimumOn1 sin (32 :| [64, 8, 128, 16])
     16.0
     -}
-    minimumOn1 :: (Ord b, Foldable1 f) => (a -> b) -> f a -> a
+    minimumOn1 :: Ord b => (a -> b) -> f a -> a
 
 {- |
 


### PR DESCRIPTION
Resolves #306

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [x] I've added the `[ci skip]` text to the docs-only related commit's name.

I don't know if it's possible to define a default implementation for `maximumOn1` and `minimumOn1`. I've not added them to the `MINIMAL` pragma for now. I'll try to provide default implementations if there are any suggestions.
