### PR TITLE
[#311] Add `maybeAt`, `!!?` with its arguments flipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog is available [on GitHub][2].
 * Upgrade to GHC-8.10.3, GHC-8.8.4.
 * Add `infinitely` as more strictly typed `forever`.
 * Remove `Eq` constraint on `universeNonEmpty`
+* Add `maybeAt`, `!!?` with its arguments flipped.
 
 ## 0.7.0.0 — May 14, 2020
 

--- a/src/Relude/List.hs
+++ b/src/Relude/List.hs
@@ -3,7 +3,7 @@
 {- |
 Copyright:  (c) 2016 Stephen Diehl
             (c) 2016-2018 Serokell
-            (c) 2018-2020 Kowainik
+            (c) 2018-2021 Kowainik
 SPDX-License-Identifier: MIT
 Maintainer:  Kowainik <xrom.xkov@gmail.com>
 Stability:   Stable
@@ -18,24 +18,26 @@ module Relude.List
     , module Relude.List.NonEmpty
       -- $nonempty
     , (!!?)
+    , maybeAt
     , partitionWith
     ) where
 
 
 import Relude.Base ((<))
 import Relude.Bool (otherwise)
+import Relude.Function (flip, (.))
 import Relude.List.NonEmpty
 import Relude.List.Reexport
-import Relude.Monad (Maybe (..), partitionEithers, Either)
+import Relude.Monad (Either, Maybe (..), partitionEithers)
 import Relude.Numeric (Int, (-))
-import Relude.Function ((.))
 
 
 -- $setup
 -- >>> import Relude
 
 {- | Safer version of 'Relude.Unsafe.!!', returns a Maybe.
-get element from list using index value starting from `0`.
+
+Get element from list using index value starting from `0`.
 
 >>> [] !!? 0
 Nothing
@@ -62,6 +64,27 @@ infix 9 !!?
     go j (_:ys) = go (j - 1) ys
     go _ []     = Nothing
 {-# INLINE (!!?) #-}
+
+{- | '!!?' with its arguments flipped.
+
+Get element from list using index value starting from `0`.
+
+>>> maybeAt 0 []
+Nothing
+
+>>> maybeAt 3 ["a", "b", "c"]
+Nothing
+
+>>> maybeAt (-1) [1, 2, 3]
+Nothing
+
+>>> maybeAt 2 ["a", "b", "c"]
+Just "c"
+
+-}
+maybeAt :: Int -> [a] -> Maybe a
+maybeAt = flip (!!?)
+{-# INLINE maybeAt #-}
 
 {- | Partitions a list based on the result of function which produces an Either value. List of all elements producing Left are extracted, in order, to the first element of the output tuple. Similarly, a list of all elements producing Right are extracted to the second element of output.
 


### PR DESCRIPTION
Resolves #311

Hi @chshersh! This wasn't assigned to anyone so I thought I'd give it a go, hope that was OK.

As for the naming: I didn't use one of your suggestions and came up with `maybeAt` for this but let me know if you all would prefer one of the others in the list. AFAIKT this wouldn't cause any name conflicts so just left it under `Relude.List`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [X] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [X] All new and existing tests pass.
- [X] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [X] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [X] My change requires the documentation updates.
  - [X] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
