### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/relude.cabal
+++ b/relude.cabal
@@ -198,7 +198,7 @@ library
                            Relude.Unsafe
 
 
-  build-depends:       bytestring ^>= 0.10
+  build-depends:       bytestring >= 0.10 && < 0.12
                      , containers >= 0.5.7 && < 0.7
                      , deepseq ^>= 1.4
                      , ghc-prim >= 0.4.0.0 && < 0.7


### PR DESCRIPTION
Resolves #349. I did not update `CHANGELOG`, because it seems that it is not customary to reflect there changes of this nature (at least I do not see any such entries).

## Checklist:

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
