### PR TITLE
[#346] Implement `ordNub` using `nubOrd` from `containers` for better efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The changelog is available [on GitHub][2].
 * Add `infinitely` as more strictly typed `forever`.
 * Remove `Eq` constraint on `universeNonEmpty`
 * Add `maybeAt`, `!!?` with its arguments flipped.
+* [#346](https://github.com/kowainik/relude/issues/346):
+  Reimplement `ordNub` through `nubOrd` from `containers`.
+
+  Add `intNub` and `intNubOn` functions.
 
 ## 0.7.0.0 — May 14, 2020
 

--- a/README.md
+++ b/README.md
@@ -494,7 +494,8 @@ Finally, let's move to part describing the new cool features we bring with
 
 * `uncons` splits a list at the first element.
 * `ordNub` and `sortNub` are _O(n log n)_ versions of `nub` (which is quadratic),
-  also, `hashNub` and `unstableNub` are almost _O(n)_ versions of `nub`.
+  also, `hashNub` and `unstableNub` are almost _O(n)_ versions of `nub`,
+  and `intNub` for fast `Int`s nub.
 * `whenM`, `unlessM`, `ifM`, `guardM` — monadic guard combinators, that work
   with any `Monad`, e.g. `whenM (doesFileExist "foo")`.
 * General fold functions:

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Main (main) where
 
 import Relude hiding (show)
@@ -17,8 +19,12 @@ main = defaultMain
     , bgroupList listOfBig      "big"
     , bgroupList (nStrings 'z') "small str"
     , bgroupList (nStrings 'c') "big str"
+
+#if __GLASGOW_HASKELL__ > 804
     , bgroupIntList listOfSmall "small ints"
     , bgroupIntList listOfBig   "big ints"
+#endif
+
     , bgroupFold
     ]
 
@@ -66,6 +72,7 @@ bgroupList f name = bgroup name $ map ($ f)
     safeSort :: [a] -> [a]
     safeSort = map NonEmpty.head . NonEmpty.group . sort
 
+#if __GLASGOW_HASKELL__ > 804
 bgroupIntList
     :: (Int -> [Int])
     -> String
@@ -90,6 +97,7 @@ bgroupIntList f name = bgroup name $ map ($ f)
             [ bench "ordNub" $ nf ordNub listN
             , bench "intNub" $ nf intNub listN
             ]
+#endif
 
 listOfSmall :: Int -> [Int]
 listOfSmall n = let part = n `div` 100 in concat $ replicate part [1..100]

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -17,6 +17,8 @@ main = defaultMain
     , bgroupList listOfBig      "big"
     , bgroupList (nStrings 'z') "small str"
     , bgroupList (nStrings 'c') "big str"
+    , bgroupIntList listOfSmall "small ints"
+    , bgroupIntList listOfBig   "big ints"
     , bgroupFold
     ]
 
@@ -63,6 +65,31 @@ bgroupList f name = bgroup name $ map ($ f)
 
     safeSort :: [a] -> [a]
     safeSort = map NonEmpty.head . NonEmpty.group . sort
+
+bgroupIntList
+    :: (Int -> [Int])
+    -> String
+    -> Benchmark
+bgroupIntList f name = bgroup name $ map ($ f)
+    [ bgroupNub 100
+    , bgroupNub 500
+    , bgroupNub 1000
+    , bgroupNub 5000
+    , bgroupNub 500000
+    , bgroupNub 1000000
+    ]
+  where
+    bgroupNub :: Int -> (Int -> [Int]) -> Benchmark
+    bgroupNub n listOf = bgroup (show n) nubBenchs
+      where
+        listN :: [Int]
+        listN = listOf n
+
+        nubBenchs :: [Benchmark]
+        nubBenchs =
+            [ bench "ordNub" $ nf ordNub listN
+            , bench "intNub" $ nf intNub listN
+            ]
 
 listOfSmall :: Int -> [Int]
 listOfSmall n = let part = n `div` 100 in concat $ replicate part [1..100]

--- a/src/Relude/Nub.hs
+++ b/src/Relude/Nub.hs
@@ -3,7 +3,7 @@
 {- |
 Copyright:  (c) 2016 Stephen Diehl
             (c) 2016-2018 Serokell
-            (c) 2018-2020 Kowainik
+            (c) 2018-2021 Kowainik
 SPDX-License-Identifier: MIT
 Maintainer:  Kowainik <xrom.xkov@gmail.com>
 Stability:   Stable
@@ -27,6 +27,10 @@ Functions to remove duplicates from a list.
 
  * 'hashNub' is the fastest with 'Data.Text.Text'.
 
+ * 'intNub' is faster when you work with lists of 'Int's.
+
+ * 'intNubOn' is fast with the lists of type that can have fixed number representations.
+
  * 'sortNub' has better performance than 'ordNub' but should be used when sorting is also needed.
 
  * 'unstableNub' has better performance than 'hashNub' but doesn't save the original order.
@@ -35,6 +39,8 @@ Functions to remove duplicates from a list.
 module Relude.Nub
     ( hashNub
     , ordNub
+    , intNub
+    , intNubOn
     , sortNub
     , unstableNub
     ) where
@@ -43,27 +49,27 @@ import Data.Eq (Eq)
 import Data.Hashable (Hashable)
 import Data.HashSet as HashSet
 import Data.Ord (Ord)
-import Prelude ((.))
+import Prelude (Int, (.))
 
 import qualified Data.Set as Set
+import qualified Data.Containers.ListUtils as Containers
 
 
-{- | Like 'Prelude.nub' but runs in \( O(n \log n) \)  time and requires 'Ord'.
+-- $setup
+-- >>> import Prelude (fromEnum)
+
+{- | Removes duplicate elements from a list, keeping only the first occurance of
+the element.
+
+Like 'Prelude.nub' but runs in \( O(n \log n) \)  time and requires 'Ord'.
 
 >>> ordNub [3, 3, 3, 2, 2, -1, 1]
 [3,2,-1,1]
 
 -}
 ordNub :: forall a . (Ord a) => [a] -> [a]
-ordNub = go Set.empty
-  where
-    go :: Set.Set a -> [a] -> [a]
-    go _ []     = []
-    go s (x:xs) =
-      if x `Set.member` s
-      then go s xs
-      else x : go (Set.insert x s) xs
-{-# INLINEABLE ordNub #-}
+ordNub = Containers.nubOrd
+{-# INLINE ordNub #-}
 
 {- | Like 'Prelude.nub' but runs in \( O(n \log_{16} n) \)  time and requires 'Hashable'.
 
@@ -101,3 +107,30 @@ sortNub = Set.toList . Set.fromList
 unstableNub :: (Eq a, Hashable a) => [a] -> [a]
 unstableNub = HashSet.toList . HashSet.fromList
 {-# INLINE unstableNub #-}
+
+
+{- | Removes duplicate elements from a list, keeping only the first occurance of
+the element.
+
+Like 'Prelude.nub' but runs in \( O(n \min\(n, int_bits\)) \)  time and requires 'Ord'.
+
+>>> intNub [3, 3, 3, 2, 2, -1, 1]
+[3,2,-1,1]
+
+@since x.x.x.x
+-}
+intNub :: [Int] -> [Int]
+intNub = Containers.nubInt
+
+{-# INLINE intNub #-}
+
+{- | Similar to 'intNub' but works on lists of any types by performing "nubbing" through 'Int's.
+
+>>> intNubOn fromEnum "ababbbcdaffee"
+"abcdfe"
+
+@since x.x.x.x
+-}
+intNubOn :: (a -> Int) -> [a] -> [a]
+intNubOn = Containers.nubIntOn
+{-# INLINE intNubOn #-}

--- a/test/Test/Relude/Property.hs
+++ b/test/Test/Relude/Property.hs
@@ -62,7 +62,6 @@ prop_BytesTo = property $ do
 listProps :: Group
 listProps = Group "list function property tests"
     [ ("ordNub xs == nub xs:", prop_ordNubCorrect)
-    , ("intNub xs == nub xs:", prop_intNubCorrect)
     , ("hashNub xs == nub xs:", prop_hashNubCorrect)
     , ("sortNub xs == sort (nub xs):" , prop_sortNubCorrect)
     , ("sort (unstableNub xs) == sort (nub xs):" , prop_unstableNubCorrect)
@@ -87,11 +86,6 @@ prop_unstableNubCorrect :: Property
 prop_unstableNubCorrect = property $ do
     xs <- forAll genIntList
     sort (unstableNub xs) === sortNub xs
-
-prop_intNubCorrect :: Property
-prop_intNubCorrect = property $ do
-    xs <- forAll genIntList
-    intNub xs === nub xs
 
 ----------------------------------------------------------------------------
 -- logicM

--- a/test/Test/Relude/Property.hs
+++ b/test/Test/Relude/Property.hs
@@ -62,6 +62,7 @@ prop_BytesTo = property $ do
 listProps :: Group
 listProps = Group "list function property tests"
     [ ("ordNub xs == nub xs:", prop_ordNubCorrect)
+    , ("intNub xs == nub xs:", prop_intNubCorrect)
     , ("hashNub xs == nub xs:", prop_hashNubCorrect)
     , ("sortNub xs == sort (nub xs):" , prop_sortNubCorrect)
     , ("sort (unstableNub xs) == sort (nub xs):" , prop_unstableNubCorrect)
@@ -86,6 +87,11 @@ prop_unstableNubCorrect :: Property
 prop_unstableNubCorrect = property $ do
     xs <- forAll genIntList
     sort (unstableNub xs) === sortNub xs
+
+prop_intNubCorrect :: Property
+prop_intNubCorrect = property $ do
+    xs <- forAll genIntList
+    intNub xs === nub xs
 
 ----------------------------------------------------------------------------
 -- logicM


### PR DESCRIPTION
Resolves #346

Benchmarks show that `intNub` is at least 2-times faster than `ordNub` (the difference is bigger on smaller lists).