### PR TITLE
Doc: note on `foldr1` difference

### DIFF
--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -91,7 +91,7 @@ class Foldable f => Foldable1 f where
     2 :| []
     -}
     toNonEmpty :: f a -> NonEmpty a
-    toNonEmpty = foldMap1 (:|[])
+    toNonEmpty = foldMap1 one
 
     {- | The first element of a non-empty data structure.
 
@@ -182,7 +182,7 @@ instance Foldable1 NonEmpty where
     {-# INLINE minimum1 #-}
 
     maximumOn1 :: forall a b. Ord b => (a -> b) -> NonEmpty a -> a
-    maximumOn1 func = foldl1' $ cmpOn
+    maximumOn1 func = foldl1' cmpOn
       where
         cmpOn :: a -> a -> a
         cmpOn a b = case func a `compare` func b of
@@ -191,7 +191,7 @@ instance Foldable1 NonEmpty where
     {-# INLINE maximumOn1 #-}
 
     minimumOn1 :: forall a b. Ord b => (a -> b) -> NonEmpty a -> a
-    minimumOn1 func = foldl1' $ cmpOn
+    minimumOn1 func = foldl1' cmpOn
       where
         cmpOn :: a -> a -> a
         cmpOn a b = case func a `compare` func b of
@@ -213,7 +213,7 @@ instance Foldable1 Identity where
     {-# INLINE fold1 #-}
 
     toNonEmpty :: Identity a -> NonEmpty a
-    toNonEmpty = (:|[]) . coerce
+    toNonEmpty = one . coerce
     {-# INLINE toNonEmpty #-}
 
     head1 :: Identity a -> a
@@ -254,7 +254,7 @@ instance Foldable1 ((,) c) where
     {-# INLINE fold1 #-}
 
     toNonEmpty :: (c, a) -> NonEmpty a
-    toNonEmpty (_, y) = (y :| [])
+    toNonEmpty (_, y) = y :| []
     {-# INLINE toNonEmpty #-}
 
     head1, last1 :: (c, a) -> a

--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -76,6 +76,9 @@ class Foldable f => Foldable1 f where
     >>> foldr1 (+) 1 $ Identity 3
     4
 
+    Note: differs from less general @base: Data.Foldable ( foldr1 )@, which has no base case:
+    > Data.Foldable.foldr1 :: Foldable t => (a -> a -> a) -> t a -> a
+
     @since 1.0.0.0
     -}
     foldr1 :: (a -> b -> b) -> b -> f a -> b


### PR DESCRIPTION
Resolves #373.

### General

- [x] I've added the `[ci skip]` text to the docs-only related commit's name.

---

Also: `(:|[])` is `one = NE.:|[]` that has inlined, & included other small lint things.