### PR TITLE
GHC 9.2.1 compatibility - Remove Option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - "8.8.4"
           - "8.10.4"
           - "9.0.1"
+          - "9.2.1"
         exclude:
           - os: macOS-latest
             ghc: 9.0.1

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2722,16 +2722,6 @@
     note: "'getSum' is already exported from Relude"
     rhs: getSum
 - warn:
-    lhs: Data.Semigroup.Option
-    name: "Use 'Option' from Relude"
-    note: "'Option' is already exported from Relude"
-    rhs: Option
-- warn:
-    lhs: Data.Semigroup.getOption
-    name: "Use 'getOption' from Relude"
-    note: "'getOption' is already exported from Relude"
-    rhs: getOption
-- warn:
     lhs: Data.Semigroup.Semigroup
     name: "Use 'Semigroup' from Relude"
     note: "'Semigroup' is already exported from Relude"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 `relude` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
-## 1.1.0.0
+## Unreleased
 
 * Remove Option from Data.Semigroup (which was removed from base in base 4.16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 `relude` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 1.1.0.0
+
+* Remove Option from Data.Semigroup (which was removed from base in base 4.16)
+
 ## 1.0.0.1 — Mar 15, 2021
 
 * Minor documentation changes.

--- a/hlint/hlint.dhall
+++ b/hlint/hlint.dhall
@@ -823,8 +823,6 @@ in [ Rule.Arguments { arguments =
    , warnReexport "getProduct" "Data.Monoid"
    , warnReexport "Sum"        "Data.Monoid"
    , warnReexport "getSum"     "Data.Monoid"
-   , warnReexport "Option"                 "Data.Semigroup"
-   , warnReexport "getOption"              "Data.Semigroup"
    , warnReexport "Semigroup"              "Data.Semigroup"
    , warnReexport "sconcat"                "Data.Semigroup"
    , warnReexport "stimes"                 "Data.Semigroup"

--- a/relude.cabal
+++ b/relude.cabal
@@ -104,7 +104,7 @@ source-repository head
   location: git@github.com:kowainik/relude.git
 
 common common-options
-  build-depends:       base >= 4.10 && < 4.16
+  build-depends:       base >= 4.10 && < 4.17
 
   ghc-options:         -Wall
                        -Wcompat
@@ -224,7 +224,7 @@ library
   build-depends:       bytestring >= 0.10 && < 0.12
                      , containers >= 0.5.7 && < 0.7
                      , deepseq ^>= 1.4
-                     , ghc-prim >= 0.4.0.0 && < 0.8
+                     , ghc-prim >= 0.4.0.0 && < 0.9
                      , hashable >= 1.2 && < 1.4
                      , mtl ^>= 2.2
                      , stm >= 2.4 && < 2.6

--- a/src/Relude/Monoid.hs
+++ b/src/Relude/Monoid.hs
@@ -37,7 +37,7 @@ import Data.Monoid (Ap (..))
 #endif
 import Data.Monoid (All (..), Alt (..), Any (..), Dual (..), Endo (..), First (..), Last (..),
                     Monoid (..), Product (..), Sum (..))
-import Data.Semigroup (Option (..), Semigroup (sconcat, stimes, (<>)), WrappedMonoid, cycle1,
+import Data.Semigroup (Semigroup (sconcat, stimes, (<>)), WrappedMonoid, cycle1,
                        mtimesDefault, stimesIdempotent, stimesIdempotentMonoid, stimesMonoid)
 
 import Relude.Bool.Reexport (Bool (..))


### PR DESCRIPTION
Also resolves #363

Blocked as of 2021-11-23 - tests are waiting on some dependencies to be able to build.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [x] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [x] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [x] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [ ] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
