### PR TITLE
Future-proof re-exports from Data.Eq

### DIFF
--- a/relude.cabal
+++ b/relude.cabal
@@ -257,7 +257,7 @@ test-suite relude-doctest
   main-is:             Doctest.hs
 
   build-depends:       relude
-                     , doctest
+                     , doctest < 0.19
                      , Glob
 
   ghc-options:         -threaded

--- a/src/Relude/Base.hs
+++ b/src/Relude/Base.hs
@@ -50,7 +50,7 @@ import Data.Char (Char, chr)
 import System.IO (FilePath, IO, IOMode (..))
 
 -- Base typeclasses
-import Data.Eq (Eq (..))
+import Data.Eq (Eq, (==), (/=))
 import Data.Ord (Down (..), Ord (..), Ordering (..), comparing)
 
 -- Types for type-level computation


### PR DESCRIPTION
Resolves #390

I left CHANGELOG untouched, because there is currently no entry for unreleased changes, and I'm not sure whether this change requires an entry: it does not change anything for existing GHCs. Happy to add an entry, if you deem it worthwhile.

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
