### PR TITLE
added 'Relude.List.permutations'

### DIFF
--- a/src/Relude/List.hs
+++ b/src/Relude/List.hs
@@ -20,16 +20,18 @@ module Relude.List
     , (!!?)
     , maybeAt
     , partitionWith
+    , permutations
     ) where
 
 
 import Relude.Base ((<))
 import Relude.Bool (otherwise)
-import Relude.Function (flip, (.))
+import Relude.Function (flip, (.), id)
 import Relude.List.NonEmpty
 import Relude.List.Reexport
 import Relude.Monad (Either, Maybe (..), partitionEithers)
 import Relude.Numeric (Int, (-))
+import Relude.Foldable (foldr)
 
 
 -- $setup
@@ -107,6 +109,29 @@ are extracted to the second element of output.
 partitionWith :: (a -> Either b c) -> [a] -> ([b], [c])
 partitionWith f = partitionEithers . map f
 {-# INLINE partitionWith #-}
+
+{- | The 'permutations' function returns the list of all permutations of the argument.
+Unlike its Prelude implementation, thiv version returns NonEmpty.
+
+>>> permutations "abc"
+"abc" :| ["bac","cba","bca","cab","acb"]
+
+>>> permutations []
+[] :| []
+
+@since 1.1.0.0
+-}
+permutations            :: [a] -> NonEmpty [a]
+permutations xs0        =  xs0 :| perms xs0 []
+  where
+    perms []     _  = []
+    perms (t:ts) is = foldr interleave (perms ts (t:is)) (permutations is)
+      where interleave    xs     r = let (_,zs) = interleave' id xs r in zs
+            interleave' _ []     r = (ts, r)
+            interleave' f (y:ys) r = let (us,zs) = interleave' (f . (y:)) ys r
+                                     in  (y:us, f (t:y:us) : zs)
+{-# INLINE permutations #-}
+
 
 {- $reexport
 Most of the "Data.List" types and function.

--- a/src/Relude/List/Reexport.hs
+++ b/src/Relude/List/Reexport.hs
@@ -21,7 +21,7 @@ module Relude.List.Reexport
 
 import Data.List (break, drop, dropWhile, filter, genericDrop, genericLength, genericReplicate,
                   genericSplitAt, genericTake, group, inits, intercalate, intersperse, isPrefixOf,
-                  iterate, map, permutations, repeat, replicate, reverse, scanl, scanl', scanl1,
+                  iterate, map, repeat, replicate, reverse, scanl, scanl', scanl1,
                   scanr, scanr1, sort, sortBy, sortOn, span, splitAt, subsequences, tails, take,
                   takeWhile, transpose, uncons, unfoldr, unzip, unzip3, zip, zip3, zipWith, (++))
 import GHC.Exts (sortWith)


### PR DESCRIPTION
Resolves #{385}

I've done this one in the image and likeness of #{319}. However, this one actually changes the exposed interface, so I'm not sure whether I should change the `hlint.dhall` and how. The same goes for the documentation as I'm not entirely sure what to put there.

Also, as I assumed from the milestone, this would be introduced in 1.1.0.0, so I've placed the @since tag accordingly. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ x ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ x ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [ x ] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ x ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
