### PR TITLE
Raise upper bound on `hashable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 `relude` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## Unreleased
+
+* Support `hashable ^>=1.4`
+
 ## 1.0.0.1 — Mar 15, 2021
 
 * Minor documentation changes.

--- a/relude.cabal
+++ b/relude.cabal
@@ -225,7 +225,7 @@ library
                      , containers >= 0.5.7 && < 0.7
                      , deepseq ^>= 1.4
                      , ghc-prim >= 0.4.0.0 && < 0.8
-                     , hashable >= 1.2 && < 1.4
+                     , hashable >= 1.2 && < 1.5
                      , mtl ^>= 2.2
                      , stm >= 2.4 && < 2.6
                      , text ^>= 1.2

--- a/src/Relude/Nub.hs
+++ b/src/Relude/Nub.hs
@@ -51,7 +51,9 @@ module Relude.Nub
     , unstableNub
     ) where
 
+#if !MIN_VERSION_hashable(1,4,0)
 import Data.Eq (Eq)
+#endif
 import Data.Hashable (Hashable)
 import Data.HashSet as HashSet
 import Data.Ord (Ord)
@@ -112,7 +114,11 @@ ordNubOn = Containers.nubOrdOn
 [3,2,-1,1]
 
 -}
+#if MIN_VERSION_hashable(1,4,0)
+hashNub :: forall a . (Hashable a) => [a] -> [a]
+#else
 hashNub :: forall a . (Eq a, Hashable a) => [a] -> [a]
+#endif
 hashNub = go HashSet.empty
   where
     go :: HashSet.HashSet a -> [a] -> [a]
@@ -139,7 +145,11 @@ sortNub = Set.toList . Set.fromList
 [1,2,3,-1]
 
 -}
+#if MIN_VERSION_hashable(1,4,0)
+unstableNub :: (Hashable a) => [a] -> [a]
+#else
 unstableNub :: (Eq a, Hashable a) => [a] -> [a]
+#endif
 unstableNub = HashSet.toList . HashSet.fromList
 {-# INLINE unstableNub #-}
 


### PR DESCRIPTION
Resolves #394 

Generates a couple of warnings with `hashable-1.4`, because `Eq` is now a superclass of `Hashable`:

```
src/Relude/Nub.hs:115:1: warning: [-Wredundant-constraints]
    • Redundant constraint: Eq a
    • In the type signature for:
           hashNub :: forall a. (Eq a, Hashable a) => [a] -> [a]
    |
115 | hashNub :: forall a . (Eq a, Hashable a) => [a] -> [a]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Relude/Nub.hs:142:1: warning: [-Wredundant-constraints]
    • Redundant constraint: Eq a
    • In the type signature for:
           unstableNub :: forall a. (Eq a, Hashable a) => [a] -> [a]
    |
142 | unstableNub :: (Eq a, Hashable a) => [a] -> [a]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I can fix the type signatures with CPP if you like.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [X] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [X] All new and existing tests pass.
- [X] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [X] I've added the `[ci skip]` text to the docs-only related commit's name.
