### PR TITLE
[#372] Warn on usages of`readFileText` and `writeFileText`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The changelog is available [on GitHub][2].
 ## Unreleased
 
 * Remove Option from Data.Semigroup (which was removed from base in base 4.16)
+* [#372](https://github.com/kowainik/relude/issues/372):
+  Warn on usages of `readFileText`, `readFileLText`, `readFile` and `readFile'`.
 * Support `hashable ^>=1.4`
 
 ## 1.0.0.1 — Mar 15, 2021

--- a/src/Relude/File.hs
+++ b/src/Relude/File.hs
@@ -20,6 +20,15 @@ also faster since they don't check encoding). However, you can then decode that
 data with the help of functions from the "Relude.String.Conversion" module, e. g.
 'Relude.String.Conversion.decodeUtf8'.
 
+To be more precise, avoid the following functions:
+
+* 'readFileText'
+* 'readFileLText'
+
+See the following blog post for more details:
+
+* [Beware of readFile by Michael Snoyman](https://www.snoyman.com/blog/2016/12/beware-of-readfile/)
+
 @since 0.3.0
 -}
 
@@ -68,6 +77,7 @@ readFileText :: MonadIO m => FilePath -> m Text
 readFileText = liftIO . T.readFile
 {-# SPECIALIZE readFileText :: FilePath -> IO Text #-}
 {-# INLINE     readFileText #-}
+{-# WARNING readFileText ["'readFileText' depends on the system's locale settings and can throw unexpected exceptions.", "Use 'readFileBS' instead."] #-}
 
 {- | Lifted version of 'T.writeFile'.
 
@@ -99,6 +109,7 @@ readFileLText :: MonadIO m => FilePath -> m LText
 readFileLText = liftIO . LT.readFile
 {-# SPECIALIZE readFileLText :: FilePath -> IO LText #-}
 {-# INLINE     readFileLText #-}
+{-# WARNING readFileLText ["'readFileLText' depends on the system's locale settings and can throw unexpected exceptions.", "Use 'readFileLBS' instead."] #-}
 
 {- | Lifted version of 'LT.writeFile'.
 

--- a/src/Relude/Lifted/File.hs
+++ b/src/Relude/Lifted/File.hs
@@ -35,6 +35,7 @@ readFile :: MonadIO m => FilePath -> m String
 readFile = liftIO . IO.readFile
 {-# SPECIALIZE readFile :: FilePath -> IO String #-}
 {-# INLINE readFile #-}
+{-# WARNING readFile ["'readFile' depends on the system's locale settings and can throw unexpected exceptions.", "Use 'readFileBS' or 'readFileLBS' instead."] #-}
 
 #if ( __GLASGOW_HASKELL__ >= 900 )
 {- | Lifted version of 'IO.readFile''. Strict version of 'readFile'.
@@ -45,6 +46,7 @@ readFile' :: MonadIO m => FilePath -> m String
 readFile' = liftIO . IO.readFile'
 {-# SPECIALIZE readFile' :: FilePath -> IO String #-}
 {-# INLINE readFile' #-}
+{-# WARNING readFile' ["readFile' depends on the system's locale settings and can throw unexpected exceptions.", "Use 'readFileBS' or 'readFileLBS' instead."] #-}
 #endif
 
 -- | Lifted version of 'IO.writeFile'.


### PR DESCRIPTION
Resolves #372

Here is an example of exceptions:

```shell
chshersh@ubuntu:~$ cat test.txt 
Привет!

chshersh@ubuntu:~$ file --mime test.txt 
test.txt: text/plain; charset=utf-8

chshersh@ubuntu:~$ LANG=en_GB.UTF-16 cabal repl -b text
Resolving dependencies...
Build profile: -w ghc-9.2.1 -O1
In order, the following will be built (use -v for more details):
 - fake-package-0 (lib) (first run)
Configuring library for fake-package-0..
Preprocessing library for fake-package-0..
Warning: No exposed modules
GHCi, version 9.2.1: https://www.haskell.org/ghc/  :? for help

ghci> readFile "test.txt" 
"*** Exception: test.txt: hGetContents: invalid argument (invalid byte sequence)
ghci> import qualified Data.Text.IO as TIO
ghci> TIO.readFile "test.txt" 
*** Exception: test.txt: hGetContents: invalid argument (invalid byte sequence)
ghci> import qualified Data.Text.Lazy.IO as LTIO
ghci> LTIO.readFile "test.txt" 
"*** Exception: test.txt: hGetContents: invalid argument (invalid byte sequence)
```