### PR TITLE
Switch from criterion to tasty-bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changelog is available [on GitHub][2].
 * [#372](https://github.com/kowainik/relude/issues/372):
   Warn on usages of `readFileText`, `readFileLText`, `readFile` and `readFile'`.
 * Support `hashable ^>=1.4`
+* Switch benchmarks from `criterion` to `tasty-bench`.
 
 ## 1.0.0.1 — Mar 15, 2021
 

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -5,8 +5,7 @@ module Main (main) where
 import Relude hiding (show)
 
 import Data.List (nub)
-import Criterion (Benchmark, bench, bgroup, nf)
-import Criterion.Main (defaultMain)
+import Test.Tasty.Bench (Benchmark, bench, bgroup, defaultMain, nf)
 import Prelude (show)
 
 import qualified Data.HashSet as HashSet (insert)

--- a/relude.cabal
+++ b/relude.cabal
@@ -270,9 +270,7 @@ benchmark relude-benchmark
   main-is:             Main.hs
 
   build-depends:       relude
-                     , criterion
+                     , tasty-bench
                      , unordered-containers
 
-  ghc-options:         -threaded
-                       -rtsopts
-                       -with-rtsopts=-N
+  ghc-options:         -rtsopts


### PR DESCRIPTION
Resolves #408.

I've also removed `ghc-options: -threaded -with-rtsopts=-N` from benchmark component. One is unlikely to intend running benchmarks concurrently, it's harmful for results. See https://github.com/quchen/prettyprinter/issues/197 for a similar discussion.

## Checklist:

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
