### PR TITLE
fix: Fix typo in comment for `infinitely`

### DIFF
--- a/src/Relude/Monad.hs
+++ b/src/Relude/Monad.hs
@@ -53,7 +53,7 @@ chainedTo = (=<<)
 
 {- | Repeat a monadic action indefinitely.
 
-This is a more type safe version of 'forever', which has a convinient
+This is a more type safe version of 'forever', which has a convenient
 but unsafe type.
 
 Consider the following two examples. In the @getIntForever@ functions, it


### PR DESCRIPTION
This PR fixes a small typo in the Haddock comment for `infinitely`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
