### PR TITLE
Allow mtl-2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 `relude` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 1.1.1.0 - Feb 2, 2023
+
+* [#432](https://github.com/kowainik/relude/pull/432):
+  Support mtl-2.3.
+
 ## 1.1.0.0 — Jun 9, 2022
 
 * [#388](https://github.com/kowainik/relude/issues/388):

--- a/relude.cabal
+++ b/relude.cabal
@@ -232,7 +232,7 @@ library
                      , deepseq ^>= 1.4
                      , ghc-prim >= 0.4.0.0 && < 0.9
                      , hashable >= 1.2 && < 1.5
-                     , mtl ^>= 2.2
+                     , mtl >= 2.2 && < 2.4
                      , stm >= 2.4 && < 2.6
                      , text >= 1.2 && < 2.1
                      , transformers >= 0.5 && < 0.7


### PR DESCRIPTION
Hi,

[mtl 2.3.1](https://hackage.haskell.org/package/mtl) has been released for about a month, and the latest version of `relude` is preventing me from updating.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [ ] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [x] I've added the `[ci skip]` text to the docs-only related commit's name.
