### PR TITLE
Update dependencies for ghc 9.6 and ghc-prim 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 `relude` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 1.2.0.1 - TBD
+
+* Support GHC-9.6
+* Upgrade dependencies:
+    - `ghc-prim-0.10`
+
 ## 1.2.0.0 – Mar 1, 2023
 
 * [#420](https://github.com/kowainik/relude/issues/420):

--- a/relude.cabal
+++ b/relude.cabal
@@ -228,11 +228,11 @@ library
     , Data.ByteString.Short
 
 
-  build-depends:       base >= 4.11 && < 4.18
+  build-depends:       base >= 4.11 && < 4.19
                      , bytestring >= 0.10 && < 0.12
                      , containers >= 0.5.10 && < 0.7
                      , deepseq ^>= 1.4
-                     , ghc-prim >= 0.5.0.0 && < 0.10
+                     , ghc-prim >= 0.5.0.0 && < 0.11
                      , hashable >= 1.2 && < 1.5
                      , mtl >= 2.2 && < 2.4
                      , stm >= 2.4 && < 2.6

--- a/src/Relude/Extra/Type.hs
+++ b/src/Relude/Extra/Type.hs
@@ -35,8 +35,15 @@ import Relude
 import Type.Reflection (typeRep)
 
 
+#if ( __GLASGOW_HASKELL__ >= 906 )
 -- $setup
 -- >>> :set -XAllowAmbiguousTypes -XDataKinds -XExplicitNamespaces -XPolyKinds -XTypeFamilies -XTypeOperators -XUndecidableInstances
+-- >>> :set -fprint-redundant-promotion-ticks
+# else
+-- $setup
+-- >>> :set -XAllowAmbiguousTypes -XDataKinds -XExplicitNamespaces -XPolyKinds -XTypeFamilies -XTypeOperators -XUndecidableInstances
+#endif
+
 
 {- | Gets a string representation of a type.
 

--- a/src/Relude/String/Conversion.hs
+++ b/src/Relude/String/Conversion.hs
@@ -102,7 +102,10 @@ class ConvertUtf8 a b where
     "\65533\65533\1090\1072\1082"
 #endif
 
-#if MIN_VERSION_text(2,0,0)
+#if MIN_VERSION_text(2,0,2)
+    >>> decodeUtf8Strict @Text @ByteString "\208\208\176\209\130\208\176\208\186"
+    Left Cannot decode byte '\xd0': Data.Text.Encoding: Invalid UTF-8 stream
+#elif MIN_VERSION_text(2,0,0)
     >>> decodeUtf8Strict @Text @ByteString "\208\208\176\209\130\208\176\208\186"
     Left Cannot decode byte '\xd0': Data.Text.Internal.Encoding: Invalid UTF-8 stream
 #else


### PR DESCRIPTION
I looked into this because relude didn't build with the latest haskell-updates branch in nixpkgs.

I've used the flake files at the bottom of this and `cabal test` to test the changes.

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.


### flake

```nix
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/haskell-updates";

  outputs = { self, nixpkgs }:
    let
      system = "x86_64-linux";
      ghc = "ghc96";
      pkgs = nixpkgs.legacyPackages.${system};

      inherit (nixpkgs.lib) composeManyExtensions;
      inherit (pkgs) fetchpatch;
      inherit (pkgs.haskell.lib) appendPatch packageSourceOverrides dontCheck;

      hspkgs = pkgs.haskell.packages.${ghc}.extend (composeManyExtensions [
        (final: prev: {
          http-chunked = dontCheck prev.http-chunked;  # not sure what's going on there
        })
        (packageSourceOverrides {
          relude = ./.;
        })
      ]);
    in {
      inherit pkgs hspkgs;
      packages.${system} = {
        inherit (hspkgs) cabal-fmt;
        inherit (pkgs) nixpkgs-fmt cabal-install;
      };
      devShells.${system}.default = hspkgs.shellFor {
        packages = p: [ p.relude ];
        buildInputs = [
          pkgs.cabal-install
          pkgs.stylish-haskell
        ];
      };
    };
}
```

```json
{
  "nodes": {
    "nixpkgs": {
      "locked": {
        "lastModified": 1682288660,
        "narHash": "sha256-S0PuNBEkHQtpNP5n5pWhhgc5egpUoSDk51xG7AZ3HF0=",
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "9d96f7a3487708d511a1318cea3e1983d648d28a",
        "type": "github"
      },
      "original": {
        "owner": "NixOS",
        "ref": "haskell-updates",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
    "root": {
      "inputs": {
        "nixpkgs": "nixpkgs"
      }
    }
  },
  "root": "root",
  "version": 7
}
```