### PR TITLE
Add hlint rule, foldr (:) [] → toList

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -190,6 +190,10 @@
     lhs: "getAlt . foldMap (Alt . f)"
     rhs: asumMap
 - hint:
+    lhs: "foldr (:) []"
+    note: "Use 'toList'"
+    rhs: toList
+- hint:
     lhs: "foldr (\\x acc -> f x <|> acc) empty"
     note: "Use 'asumMap'"
     rhs: asumMap f

--- a/hlint/hlint.dhall
+++ b/hlint/hlint.dhall
@@ -97,6 +97,7 @@ in [ Rule.Arguments { arguments =
 
    , warnSimple "getAlt (foldMap (Alt . f) xs)" "asumMap xs"
    , warnSimple "getAlt . foldMap (Alt . f)" "asumMap"
+   , hintNote "foldr (:) []" "toList" "Use 'toList'"
    , hintNote "foldr (\\x acc -> f x <|> acc) empty" "asumMap f" "Use 'asumMap'"
    , hintNote "asum (map f xs)" "asumMap f xs" "Use 'asumMap'"
 


### PR DESCRIPTION
Hi @vrom911 :wave: Long-time fan of Kowainik, here's a first contribution.

I was writing something with Relude, and had a sudden brainfart failing to remember how to say `toList` :sweat_smile:
Instead I wrote `foldr (:) []` — expecting Relude's HLint ruleset to remind me a less clumsy wording — but alas, it didn't say anything! That I was shocked, says something about the quality of kowainik stuff :wink:



## Checklist

- [x] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
- [x] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).
- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
  — :thinking:  Prolly not worth it?..

