### PR TITLE
Fix documentation typo

### DIFF
--- a/src/Relude/Nub.hs
+++ b/src/Relude/Nub.hs
@@ -69,7 +69,7 @@ import qualified Data.Containers.ListUtils as Containers
 -- $setup
 -- >>> import Prelude (div, fromEnum)
 
-{- | Removes duplicate elements from a list, keeping only the first occurance of
+{- | Removes duplicate elements from a list, keeping only the first occurrence of
 the element.
 
 Like 'Prelude.nub' but runs in \( O(n \log n) \)  time and requires 'Ord'.


### PR DESCRIPTION
## Checklist:

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [x] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [x] I've added the `[ci skip]` text to the docs-only related commit's name.
