### PR TITLE
Add function to read UTF-8 files

### DIFF
--- a/src/Relude/File.hs
+++ b/src/Relude/File.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 {- |
 Module                  : Relude.File
@@ -53,12 +54,16 @@ module Relude.File
     , readFileLBS
     , writeFileLBS
     , appendFileLBS
+
+      -- * Reading in UTF-8
+    , readFileUtf8
     ) where
 
 import Relude.Base (FilePath, IO)
 import Relude.Function ((.))
+import Relude.Functor (fmap)
 import Relude.Monad.Reexport (MonadIO (..))
-import Relude.String (ByteString, LByteString, LText, Text)
+import Relude.String (ByteString, LByteString, LText, Text, String, ConvertUtf8(..))
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
@@ -191,3 +196,21 @@ appendFileLBS :: MonadIO m => FilePath -> LByteString -> m ()
 appendFileLBS p = liftIO . LBS.appendFile p
 {-# SPECIALIZE appendFileLBS :: FilePath -> LByteString -> IO () #-}
 {-# INLINE     appendFileLBS #-}
+
+----------------------------------------------------------------------------
+-- UTF-8
+----------------------------------------------------------------------------
+
+{- | 'MonadIO'-lifted strict file reading with the assumption that it contains
+text in UTF-8 (or just ASCII) encoding.
+
+Invalid byte sequences that don't represent characters will be converted to
+U+FFFD replacement characters (@decodeUtf8Lenient@).
+
+@since ?.?.?
+-}
+readFileUtf8 :: (MonadIO m, ConvertUtf8 r ByteString) => FilePath -> m r
+readFileUtf8 = liftIO . fmap decodeUtf8 . BS.readFile
+{-# SPECIALIZE readFileUtf8 :: FilePath -> IO Text #-}
+{-# SPECIALIZE readFileUtf8 :: FilePath -> IO String #-}
+{-# INLINE     readFileUtf8 #-}


### PR DESCRIPTION
Following up to #372 and #407, consider a snippet

```haskell
 […] do
      mRssPages <- readMay @Int . (!! 1) . T.split (== ' ') <$> readFileText "/proc/self/statm"
      […]
```

Produces deprecation warning:

>     In the use of ‘readFileText’
>     "'readFileText' depends on the system's locale settings and can throw unexpected exceptions.
>      Use 'readFileBS' instead."

I've read the documented deprecations, and I fully understand the motivating [blog post][] of Mr. Snoyberg.

However, those locale concerns **simply don't apply** here. Because I'm writing code to read a guaranteed small file that's nearly guaranteed to never exceed the 12-character alphabet `0123456789 \n`.

So then, can I silence the deprecation warning on this specific use-site? No — all deprecations over the entire module only.

Sigh... :pensive: Sure, writing yet another little helper once more is far from hard:

```haskell
readFileUtf8 :: MonadIO m => FilePath -> m Text
readFileUtf8 = fmap decodeUtf8Lenient . readFileBS
```

And everybody is [doing that already][hoogle] anyway. Yet by this same reasoning, the entire `Relude.File` module is redundant.

[blog post]: https://www.snoyman.com/blog/2016/12/beware-of-readfile/
[hoogle]: https://hoogle.haskell.org/?hoogle=readFileUTF8

-----------------

Constructively: I'm proposing a function:
```haskell
readFileUtf8 :: (MonadIO m, ConvertUtf8 r ByteString) => FilePath -> m r
```

which:
* reads text from files, strictly;
* interacts nicely with Relude's `String.Conversions` module,
* thus avoids the whole clunky series `readFileUtf8Text`, `readFileUtf8LText`, `readFileUtf8String` elegantly.

I'll add lazy version on demand.

## Checklist:

### HLint

- [x] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
   — new API, no need for hlint changes.

### General

- [ ] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [x] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [x] My change requires the documentation updates.
  - [x] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
