### PR TITLE
Add foldMapA1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 `relude` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+## 1.2.3
+
+- Add `foldMapA1` function.
+
 ## 1.2.2.1 – Jul 29, 2025
 
 - Allow containers-0.8.

--- a/src/Relude/Extra/Foldable1.hs
+++ b/src/Relude/Extra/Foldable1.hs
@@ -34,6 +34,7 @@ contradiction with 'Data.Foldable.Foldable'.
 module Relude.Extra.Foldable1
     ( Foldable1 (..)
     , foldl1'
+    , foldMapA1
     , average1
     ) where
 
@@ -399,6 +400,21 @@ foldl1' :: (a -> a -> a) -> NonEmpty a -> a
 foldl1' _ (x :| [])     = x
 foldl1' f (x :| (y:ys)) = foldl' f (f x y) ys
 {-# INLINE foldl1' #-}
+
+{- | 'foldMapA' generalised to any 'Semigroup'.
+
+>>> foldMapA1 @(NonEmpty Int) (Just . replicate 3) (1 :| [2..3])
+Just (1 :| [1,1,2,2,2,3,3,3])
+
+@since 1.2.3
+-}
+foldMapA1
+    :: forall b m f a . (Semigroup b, Applicative m, Foldable1 f)
+    => (a -> m b)
+    -> f a
+    -> m b
+foldMapA1 = coerce (foldMap1 :: (a -> Ap m b) -> f a -> Ap m b)
+{-# INLINE foldMapA1 #-}
 
 {- |  Given a 'Foldable1' of 'Fractional' elements, computes the average if
 possible and returns the resulting element.


### PR DESCRIPTION
`foldMapA` is one of my favourite functions but it requires `Monoid` and I only have a `Semigroup` at the moment. I made this by copying `foldMapA` and updating it to suit. I couldn't get the doctests to run (CPP-related errors?)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [x] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
