### PR TITLE
Add missing fixity declarations for `elem` and `notElem`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog is available [on GitHub][2].
 
 - [#484](https://github.com/kowainik/relude/pull/484):
   Remove `ghc-prim` dependency.
+- [#488](https://github.com/kowainik/relude/pull/488):
+  Add missing fixity declarations for `elem` and `notElem`.
 
 ## 1.2.2.2 – Aug 5, 2025
 

--- a/src/Relude/Foldable/Fold.hs
+++ b/src/Relude/Foldable/Fold.hs
@@ -155,6 +155,7 @@ False
               not . member
 ...
 -}
+infix 4 `elem`
 elem :: (Foldable f, DisallowElem f, Eq a) => a -> f a -> Bool
 elem = F.elem
 {-# INLINE elem #-}
@@ -178,6 +179,7 @@ True
               not . member
 ...
 -}
+infix 4 `notElem`
 notElem :: (Foldable f, DisallowElem f, Eq a) => a -> f a -> Bool
 notElem = F.notElem
 {-# INLINE notElem #-}


### PR DESCRIPTION
Fixes #487.

<!-- You can add any comments here -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### HLint

- [ ] I've changed the exposed interface (add new reexports, remove reexports, rename reexported things, etc.).
  - [ ] I've updated [`hlint.dhall`](https://github.com/kowainik/relude/blob/master/hlint/hlint.dhall) accordingly to my changes (add new rules for the new imports, remove old ones, when they are outdated, etc.).
  - [ ] I've generated the new `.hlint.yaml` file (see [this instructions](https://github.com/kowainik/relude#generating-hlintyaml)).

### General

- [x] I've updated the [CHANGELOG](https://github.com/kowainik/relude/blob/master/CHANGELOG.md) with the short description of my latest changes.
- [ ] All new and existing tests pass.
- [ ] I keep the code style used in the files I've changed (see [style-guide](https://github.com/kowainik/org/blob/master/style-guide.md#haskell-style-guide) for more details).
- [ ] I've used the [`stylish-haskell` file](https://github.com/kowainik/relude/blob/master/.stylish-haskell.yaml).
- [ ] My change requires the documentation updates.
  - [ ] I've updated the documentation accordingly.
- [ ] I've added the `[ci skip]` text to the docs-only related commit's name.
